### PR TITLE
fix inline attachments and embedded images

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -209,7 +209,7 @@ class Attachment {
 
         $content = $this->part->content;
 
-        $this->content_type = $this->type.'/'.strtolower($this->part->subtype);
+        $this->content_type = $this->part->content_type;
         $this->content = $this->oMessage->decodeString($content, $this->part->encoding);
 
         if (($id = $this->part->id) !== null) {

--- a/src/Message.php
+++ b/src/Message.php
@@ -425,11 +425,8 @@ class Message {
      */
     private function fetchPart(Part $part) {
 
-        if ($part->type == IMAP::MESSAGE_TYPE_TEXT &&
-            ($part->ifdisposition == 0 ||
-                (empty($part->disposition) || strtolower($part->disposition) != 'attachment')
-            )
-        ) {
+        if ($part->type == IMAP::MESSAGE_TYPE_TEXT && ($part->ifdisposition == 0 || (empty($part->disposition) || !in_array(strtolower($part->disposition), ['attachment', 'inline'])) ) ) {
+
             if (strtolower($part->subtype) == "plain" || strtolower($part->subtype) == "csv") {
                 $encoding = $this->getEncoding($part);
 

--- a/src/Part.php
+++ b/src/Part.php
@@ -128,6 +128,13 @@ class Part {
     public $bytes = null;
 
     /**
+     * Part content type
+     *
+     * @var string|null $content_type
+     */
+    public $content_type = null;
+
+    /**
      * @var Header $header
      */
     private $header = null;
@@ -167,7 +174,24 @@ class Part {
         $this->charset = $this->header->get("charset");
         $this->name = $this->header->get("name");
         $this->filename = $this->header->get("filename");
-        $this->id = $this->header->get("id");
+
+        if(!empty($this->header->get("id"))) {
+            $this->id = $this->header->get("id");
+        } else if(!empty($this->header->get("x-attachment-id"))){
+            $this->id = $this->header->get("x-attachment-id");
+        } else if(!empty($this->header->get("content-id"))){
+            $this->id = strtr($this->header->get("content-id"), [
+                '<' => '',
+                '>' => ''
+            ]);
+        }
+
+        if(!empty($this->header->get("content-type"))){
+            $rawContentType = $this->header->get("content-type");
+            $contentTypeArray = explode(';', $rawContentType);
+            $this->content_type = trim($contentTypeArray[0]);
+        }
+
 
         $this->content = trim(rtrim($body));
         $this->bytes = strlen($this->content);

--- a/src/Support/Masks/MessageMask.php
+++ b/src/Support/Masks/MessageMask.php
@@ -36,7 +36,10 @@ class MessageMask extends Mask {
             return null;
         }
 
-        return $bodies['html']->content;
+        if(is_object($bodies['html']) && property_exists($bodies['html'], 'content')) {
+            return $bodies['html']->content;
+        }
+        return $bodies['html'];
     }
 
     /**
@@ -73,8 +76,8 @@ class MessageMask extends Mask {
     public function getHTMLBodyWithEmbeddedBase64Images() {
         return $this->getCustomHTMLBody(function($body, $oAttachment){
             /** @var \Webklex\PHPIMAP\Attachment $oAttachment */
-            if ($oAttachment->id && $oAttachment->getImgSrc() != null) {
-                $body = str_replace('cid:'.$oAttachment->id, $oAttachment->getImgSrc(), $body);
+            if ($oAttachment->id) {
+                $body = str_replace('cid:'.$oAttachment->id, 'data:'.$oAttachment->getContentType().';base64, '.base64_encode($oAttachment->getContent()), $body);
             }
 
             return $body;


### PR DESCRIPTION
My fix for MessageMask->getHTMLBodyWithEmbeddedBase64Images() - now will working correctly :)

Tested on gmail and outlook.

Additionally I added:

- Part->content_type = content type of part
- improved id part search from headers
- fix bug (non-object on MessageMask::getHtmlBody())