### PR TITLE
Add Wrapper to test if a path is used for Client::getFolder()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -372,7 +372,7 @@ class Client {
     public function getFolder($folder_name, $delimiter = null) {
         // Set delimiter to false to force selection via getFolderByName (maybe useful for uncommon folder names)
         if ($delimiter !== false) {
-            $delimiter = (is_null($delimiter)) ? $this->delimiter ?? '/' : $delimiter;
+            $delimiter = (is_null($delimiter)) ? ClientManager::get('options.delimiter', "/") : $delimiter;
             if (strpos($folder_name, $delimiter) !== false) {
                 return $this->getFolderByPath($folder_name);
             }

--- a/src/Client.php
+++ b/src/Client.php
@@ -362,13 +362,19 @@ class Client {
 
     /**
      * Get a folder instance by a folder name
-     * @param $folder_name
+     * @param string $folder_name
+     * @param string $delimiter
      *
      * @return mixed
      * @throws ConnectionFailedException
      * @throws FolderFetchingException
      */
-    public function getFolder($folder_name) {
+    public function getFolder($folder_name, $delimiter = false)
+    {
+        $delimiter = ($delimiter === false) ? $this->delimiter ?? '/' : $delimiter;
+        if (strpos($folder_name, $delimiter) !== false) {
+            return $this->getFolderByPath($folder_name);
+        }
         return $this->getFolderByName($folder_name);
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -363,18 +363,21 @@ class Client {
     /**
      * Get a folder instance by a folder name
      * @param string $folder_name
-     * @param string $delimiter
+     * @param string|bool $delimiter
      *
      * @return mixed
      * @throws ConnectionFailedException
      * @throws FolderFetchingException
      */
-    public function getFolder($folder_name, $delimiter = false)
-    {
-        $delimiter = ($delimiter === false) ? $this->delimiter ?? '/' : $delimiter;
-        if (strpos($folder_name, $delimiter) !== false) {
-            return $this->getFolderByPath($folder_name);
-        }
+    public function getFolder($folder_name, $delimiter = null) {
+        // Set delimiter to false to force selection via getFolderByName (maybe useful for uncommon folder names)
+        if ($delimiter !== false) {
+            $delimiter = (is_null($delimiter)) ? $this->delimiter ?? '/' : $delimiter;
+            if (strpos($folder_name, $delimiter) !== false) {
+                return $this->getFolderByPath($folder_name);
+            }
+	}
+
         return $this->getFolderByName($folder_name);
     }
 


### PR DESCRIPTION
Changed getFolder to validate if $folder_name is a path and switch the selection function based on the absence of a delimiting char inside the name
Default Behaviour is to test if a $folder name contains a default limiter (`$client->delimiter` or if absent "/")

See also:
https://github.com/Webklex/laravel-imap/issues/344