### PR TITLE
Fix Query pagination.

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -289,7 +289,7 @@ class Query {
 
         $this->limit = $per_page;
 
-        return $this->get()->paginate($per_page, $this->page, $page_name);
+        return $this->get()->paginate($per_page, $this->page, $page_name, true);
     }
 
     /**

--- a/src/Support/PaginatedCollection.php
+++ b/src/Support/PaginatedCollection.php
@@ -38,12 +38,12 @@ class PaginatedCollection extends Collection {
      *
      * @return LengthAwarePaginator
      */
-    public function paginate($per_page = 15, $page = null, $page_name = 'page') {
+    public function paginate($per_page = 15, $page = null, $page_name = 'page', $prepaginated = false) {
         $page = $page ?: Paginator::resolveCurrentPage($page_name);
 
         $total = $this->total ? $this->total : $this->count();
 
-        $results = $total ? $this->forPage($page, $per_page) : $this->all();
+        $results = !$prepaginated && $total ? $this->forPage($page, $per_page) : $this->all();
 
         return $this->paginator($results, $total, $per_page, $page, [
             'path'      => Paginator::resolveCurrentPath(),


### PR DESCRIPTION
Possible fix to issue #49 from @zu007. The problem is caused by the return value of Query->paginate(). ``return $this->get()->paginate($per_page, $this->page, $page_name)`` would paginate the results twice. Once by the ->get() method, and again by the ->paginate() method.