### PR TITLE
Bug getBoundary() for PHP 8 and CASE error.

### DIFF
--- a/src/Structure.php
+++ b/src/Structure.php
@@ -101,6 +101,11 @@ class Structure {
      */
     public function getBoundary(){
         $boundary = $this->header->find("/boundary=\"?([^\"]*)[\";\s]/");
+
+        if ($boundary === null) {
+            return null;
+        }
+
         return str_replace('"', '', $boundary);
     }
 

--- a/src/Structure.php
+++ b/src/Structure.php
@@ -100,7 +100,7 @@ class Structure {
      * Determine the message content type
      */
     public function getBoundary(){
-        $boundary = $this->header->find("/boundary=\"?([^\"]*)[\";\s]/");
+        $boundary = $this->header->find("/boundary=\"?([^\"]*)[\";\s]/i");
 
         if ($boundary === null) {
             return null;


### PR DESCRIPTION
There is an error in getBoundary() for PHP 8. str_replace will change a null into a empty string.
This will break the rest of the code flow for example find_parts():

```php
if (($boundary = $this->getBoundary()) === null)  {
    throw new MessageContentFetchingException("no content found", 0);
}
```

There are also mails with case boundary example:

`Content-Type: MULTIPART/RELATED; BOUNDARY="1530194440-19055-1609978869=:57168"`

This can be solved by making the regex pattern case insensetive.

Fixes Webklex/laravel-imap#385