### PR TITLE
Fixed possible php warning in Message.php class line 435

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -432,7 +432,7 @@ class Message {
                 $flag = substr($flag, 1);
             }
             $flag_key = strtolower($flag);
-            if (in_array($flag_key, $this->available_flags) || $this->available_flags === null) {
+            if ($this->available_flags === null || in_array($flag_key, $this->available_flags)) {
                 $this->flags->put($flag_key, $flag);
             }
         }


### PR DESCRIPTION
Hi @Webklex 

This is related to https://github.com/Webklex/laravel-imap/issues/391

It's a simple change of order to prevent possible php warnings