### PR TITLE
Remove duplicate if statement in setEventsFromConfig

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -220,10 +220,8 @@ class Client {
     protected function setEventsFromConfig($config) {
         $this->events = ClientManager::get("events");
         if(isset($config['events'])){
-            if(isset($config['events'])) {
-                foreach($config['events'] as $section => $events) {
-                    $this->events[$section] = array_merge($this->events[$section], $events);
-                }
+            foreach($config['events'] as $section => $events) {
+                $this->events[$section] = array_merge($this->events[$section], $events);
             }
         }
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -432,7 +432,7 @@ class Message {
                 $flag = substr($flag, 1);
             }
             $flag_key = strtolower($flag);
-            if (in_array($flag_key, $this->available_flags) || $this->available_flags === null) {
+            if ($this->available_flags === null || in_array($flag_key, $this->available_flags)) {
                 $this->flags->put($flag_key, $flag);
             }
         }


### PR DESCRIPTION
Hi @Webklex 

I noticed the following block of code in `setEventsFromConfig` in the `Client.php` class

```php
 protected function setEventsFromConfig($config) {
        $this->events = ClientManager::get("events");
        if(isset($config['events'])){
            if(isset($config['events'])) {
                foreach($config['events'] as $section => $events) {
                    $this->events[$section] = array_merge($this->events[$section], $events);
                }
            }
        }
    }
```

The if `  if(isset($config['events'])){` is duplicated here, this PR just removed the duplicate if so we are left with 

```php
protected function setEventsFromConfig($config) {
        $this->events = ClientManager::get("events");
        if(isset($config['events'])){
            foreach($config['events'] as $section => $events) {
                $this->events[$section] = array_merge($this->events[$section], $events);
            }
        }
    }
```