### PR TITLE
#126 - update regex to find boundary

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -173,7 +173,7 @@ class Header {
      * @return string|null
      */
     public function getBoundary(){
-        $boundary = $this->find("/boundary\=(.*)/i");
+        $boundary = $this->find("/boundary=\"?([^\"]*)[\";\s]/i");
 
         if ($boundary === null) {
             return null;


### PR DESCRIPTION
Related to ticket #126 .
Update the regex to find the boundary.
The regex present in the documentation works correctly, and by adding the option i (PCRE_CASELESS) to it.