### PR TITLE
IMAP 4 support

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -331,7 +331,7 @@ class Client {
         $this->disconnect();
         $protocol = strtolower($this->protocol);
 
-        if ($protocol == "imap") {
+        if (in_array($protocol, ['imap', 'imap4', 'imap4rev1'])) {
             $this->connection = new ImapProtocol($this->validate_cert, $this->encryption);
             $this->connection->setConnectionTimeout($this->timeout);
             $this->connection->setProxy($this->proxy);


### PR DESCRIPTION
Hi, @Webklex

I'd like to add **IMAP v4** support.

Because now, when I want to use _imap4rev1_ in the protocol param, the `connect()` method thinks I'm using a kind of legacy IMAP version.