### PR TITLE
fix Unexpected characters at end of address

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -428,6 +428,7 @@ class ImapProtocol extends Protocol {
             try {
                 $result = $this->requestAndResponse('LOGOUT', [], true);
             } catch (Exception $e) {}
+            imap_errors();
             fclose($this->stream);
             $this->stream = null;
         }


### PR DESCRIPTION
Clear error stack before fclose
fix error: Unexpected characters at end of address: <> (errflg=3)