### PR TITLE
POP3 fixes

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -331,7 +331,7 @@ class Client {
         $this->disconnect();
         $protocol = strtolower($this->protocol);
 
-        if (in_array($protocol, ['imap', 'imap4', 'imap4rev1'])) {
+        if ($protocol == "imap") {
             $this->connection = new ImapProtocol($this->validate_cert, $this->encryption);
             $this->connection->setConnectionTimeout($this->timeout);
             $this->connection->setProxy($this->proxy);
@@ -372,7 +372,7 @@ class Client {
             } elseif (!$this->connection->login($this->username, $this->password)) {
                 throw new AuthFailedException();
             }
-        } catch (Exception $e) {
+        } catch (AuthFailedException $e) {
             throw new ConnectionFailedException("connection setup failed", 0, $e);
         }
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -331,7 +331,7 @@ class Client {
         $this->disconnect();
         $protocol = strtolower($this->protocol);
 
-        if ($protocol == "imap") {
+        if (in_array($protocol, ['imap', 'imap4', 'imap4rev1'])) {
             $this->connection = new ImapProtocol($this->validate_cert, $this->encryption);
             $this->connection->setConnectionTimeout($this->timeout);
             $this->connection->setProxy($this->proxy);

--- a/src/Connection/Protocols/LegacyProtocol.php
+++ b/src/Connection/Protocols/LegacyProtocol.php
@@ -72,6 +72,7 @@ class LegacyProtocol extends Protocol {
      *
      * @return bool
      * @throws AuthFailedException
+     * @throws RuntimeException
      */
     public function login($user, $password) {
         try {

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -185,7 +185,7 @@ class Query {
 
         try {
             $available_messages = $this->client->getConnection()->search([$this->getRawQuery()], $this->sequence == IMAP::ST_UID);
-            return new Collection($available_messages);
+            return $available_messages !== false ? new Collection($available_messages) : new Collection();
         } catch (RuntimeException $e) {
             throw new GetMessagesFailedException("failed to fetch messages", 0, $e);
         } catch (ConnectionFailedException $e) {
@@ -216,7 +216,7 @@ class Query {
             $available_messages = $available_messages->reverse();
         }
 
-        $uids = $available_messages->forPage($this->page, $this->limit)->filter(function($message) { return $message !== false; })->toArray();
+        $uids = $available_messages->forPage($this->page, $this->limit)->toArray();
         $flags = $this->client->getConnection()->flags($uids, $this->sequence == IMAP::ST_UID);
         $headers = $this->client->getConnection()->headers($uids, "RFC822", $this->sequence == IMAP::ST_UID);
 
@@ -339,7 +339,7 @@ class Query {
         $available_messages = $this->search();
 
         try {
-            if (($available_messages_count = $available_messages->count()) > 0) {
+            if ($available_messages->count() > 0) {
                 return $this->populate($available_messages);
             }
             return MessageCollection::make([]);

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -216,7 +216,7 @@ class Query {
             $available_messages = $available_messages->reverse();
         }
 
-        $uids = $available_messages->forPage($this->page, $this->limit)->toArray();
+        $uids = $available_messages->forPage($this->page, $this->limit)->filter(function($message) { return $message !== false; })->toArray();
         $flags = $this->client->getConnection()->flags($uids, $this->sequence == IMAP::ST_UID);
         $headers = $this->client->getConnection()->headers($uids, "RFC822", $this->sequence == IMAP::ST_UID);
 


### PR DESCRIPTION
Hi,

This PR fixes POP3 connection (READONLY not handled) and empty mailbox.

About the weird additional check, with pop3, imap_open will trigger an error logged in imap_errors and displayed at the imap_close (or auto close as the end of the page) but I don't want to ignore the errors if it's not really linked with the empty mailbox, thus my additional check.