### PR TITLE
Change boundary regex

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -173,7 +173,7 @@ class Header {
      * @return string|null
      */
     public function getBoundary(){
-        $boundary = $this->find("/boundary\=(.*)/i");
+        $boundary = $this->find("/boundary=(.*?(?=;)|(.*))/i");
 
         if ($boundary === null) {
             return null;


### PR DESCRIPTION
Resolves #150 where there is other header params in the same line of boundary, 
as in 
`Content-Type: multipart/mixed; boundary="--AaZz"; filename="untitled.txt"`
instead of 
`boundary="_34f19e771ef672441eab76cca3808103"`