### PR TITLE
Expose message folder path

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -1266,6 +1266,15 @@ class Message {
     }
 
     /**
+     * Get the message path aka folder path
+     *
+     * @return string
+     */
+    public function getFolderPath(){
+        return $this->folder_path;
+    }
+
+    /**
      * Set the message path aka folder path
      * @param $folder_path
      *


### PR DESCRIPTION
Hi!

Message class has protected property `$folder_path`. Accessing it would be useful as it is initialized in the constructor by default.

Any other case includes querying for folder by using `Message::getFolder()` and then using `$path` property of the `Folder` class which is not optimal.

That's why i created this pull request.

