### PR TITLE
Added methods for moving and copying multiple messages

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -825,6 +825,25 @@ class ImapProtocol extends Protocol {
     }
 
     /**
+     * Copy multiple messages to the target folder
+     *
+     * @param array<string> $messages List of message identifiers
+     * @param string $folder Destination folder
+     * @param bool $uid Set to true if you pass message unique identifiers instead of numbers
+     * @return bool Success
+     *
+     * @throws RuntimeException
+     */
+    public function copyManyMessages($messages, $folder, $uid = false) {
+        $command = $uid ? 'UID COPY' : 'COPY';
+
+        $set = implode(',', $messages);
+        $tokens = [$set, $this->escapeString($folder)];
+
+        return $this->requestAndResponse($command, $tokens, true);
+    }
+
+    /**
      * Move a message set from current folder to an other folder
      * @param string $folder destination folder
      * @param $from

--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -846,6 +846,25 @@ class ImapProtocol extends Protocol {
     }
 
     /**
+     * Move multiple messages to the target folder
+     *
+     * @param array<string> $messages List of message identifiers
+     * @param string $folder Destination folder
+     * @param bool $uid Set to true if you pass message unique identifiers instead of numbers
+     * @return bool Success
+     *
+     * @throws RuntimeException
+     */
+    public function moveManyMessages($messages, $folder, $uid = false) {
+        $command = $uid ? 'UID MOVE' : 'MOVE';
+
+        $set = implode(',', $messages);
+        $tokens = [$set, $this->escapeString($folder)];
+
+        return $this->requestAndResponse($command, $tokens, true);
+    }
+
+    /**
      * Create a new folder (and parent folders if needed)
      * @param string $folder folder name
      *

--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -830,7 +830,7 @@ class ImapProtocol extends Protocol {
      * @param array<string> $messages List of message identifiers
      * @param string $folder Destination folder
      * @param bool $uid Set to true if you pass message unique identifiers instead of numbers
-     * @return bool Success
+     * @return array|bool Tokens if operation successful, false if an error occurred
      *
      * @throws RuntimeException
      */
@@ -870,7 +870,7 @@ class ImapProtocol extends Protocol {
      * @param array<string> $messages List of message identifiers
      * @param string $folder Destination folder
      * @param bool $uid Set to true if you pass message unique identifiers instead of numbers
-     * @return bool Success
+     * @return array|bool Tokens if operation successful, false if an error occurred
      *
      * @throws RuntimeException
      */


### PR DESCRIPTION
Currently `php-imap` exposes two methods that can move or copy range of messages to another folder:
`ImapProtocol::moveMessage` and `ImapProtocol::copyMessage`

Unfortunately they don't allow moving or copying messages that are not directly after each other.
For this specific use case I've added two methods that allow moving messages by specifying list of their identifiers.

I didn't want to modify original methods as it would be a breaking change.