### PR TITLE
Fixed problem with skipping last line of the response.

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -254,9 +254,10 @@ class ImapProtocol extends Protocol {
     public function readResponse($tag, $dontParse = false) {
         $lines = [];
         $tokens = null; // define $tokens variable before first use
-        while (!$this->readLine($tokens, $tag, $dontParse)) {
+        do {
+            $readAll = $this->readLine($tokens, $tag, $dontParse);
             $lines[] = $tokens;
-        }
+        } while (!$readAll);
 
         if ($dontParse) {
             // First two chars are still needed for the response code


### PR DESCRIPTION
Hi @Webklex,

I've found a small problem - after each IMAP operation, almost every line of the response is returned - except the last one. It was caused by a wrong while statement.

As you probably know, with @Magiczne we have recently added some improvements to allow for the mass IMAP operations.
It's known that IMAP can return new UIDs for moved or copied messages.

After your last releases, we started developing the mass operations implementation - so we wanted to use it.
Starting from the MOVE action.
In fact, moving is just copying but beefed up with EXPUNGE command at the end (to remove source messages from the source folder).
The response after successfully performed the MOVE operation should look like this:
```
[
    "OK [COPYUID 1628261695 5531,5533 1911:1912] Moved UIDs.",
    "3 EXPUNGE",
    "1 EXPUNGE",
    "OK Move completed (0.004 + 0.000 + 0.003 secs)."
]
```

but looked like this:
```
[
    "OK [COPYUID 1628261695 5531,5533 1911:1912] Moved UIDs.",
    "3 EXPUNGE",
    "1 EXPUNGE"
]
```

As you can easily realize - the last line is missing. We didn't pick it up at this moment, because in this case, we don't lose anything important.

The real problem occurred when we wanted to perform the COPY operation because there is only one response line:
```
[
    "OK [COPYUID 1628261695 5532,5535 1913:1914] Copy completed (0.004 + 0.000 + 0.003 secs)."
]
```
So, if `readResponse()` method cuts the last line, we ended up with nothing - so we had to start debugging to find the solution.