### PR TITLE
Fix attribute serialization

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -62,21 +62,12 @@ class Attribute implements ArrayAccess {
     }
 
     /**
-     * Return the serialized attribute
-     *
-     * @return array
-     */
-    public function __serialize(){
-        return $this->values;
-    }
-
-    /**
      * Convert instance to array
      *
      * @return array
      */
     public function toArray(){
-        return $this->__serialize();
+        return $this->values;
     }
 
     /**


### PR DESCRIPTION
Currently attribute serialization is broken, if an attribute is serialized and unserialized all values will appear as properties on the attribute. Serializing and unserializing again will result in a completely empty object.

See attached example
![image](https://user-images.githubusercontent.com/6945600/142245186-dd71fc99-46cb-462e-9658-fa48c49da436.png)
![image](https://user-images.githubusercontent.com/6945600/142245245-49836985-b644-488e-ac2e-6dcfa65807bb.png)

This PR fixes this problem
