### PR TITLE
Use real tls instead of starttls

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -65,7 +65,7 @@ class Client {
 
     /**
      * Server encryption.
-     * Supported: none, ssl, tls, or notls.
+     * Supported: none, ssl, tls, starttls or notls.
      *
      * @var string
      */

--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -60,12 +60,12 @@ class ImapProtocol extends Protocol {
      */
     public function connect($host, $port = null) {
         $transport = 'tcp';
-        $encryption = "";
+        $encryption = '';
 
         if ($this->encryption) {
             $encryption = strtolower($this->encryption);
-            if ($encryption == "ssl") {
-                $transport = 'ssl';
+            if (in_array($encryption, ['ssl', 'tls'])) {
+                $transport = $encryption;
                 $port = $port === null ? 993 : $port;
             }
         }
@@ -75,8 +75,8 @@ class ImapProtocol extends Protocol {
             if (!$this->assumedNextLine('* OK')) {
                 throw new ConnectionFailedException('connection refused');
             }
-            if ($encryption == "tls") {
-                $this->enableTls();
+            if ($encryption == 'starttls') {
+                $this->enableStartTls();
             }
         } catch (Exception $e) {
             throw new ConnectionFailedException('connection failed', 0, $e);
@@ -89,7 +89,7 @@ class ImapProtocol extends Protocol {
      * @throws ConnectionFailedException
      * @throws RuntimeException
      */
-    protected function enableTls(){
+    protected function enableStartTls(){
         $response = $this->requestAndResponse('STARTTLS');
         $result = $response && stream_socket_enable_crypto($this->stream, true, $this->getCryptoMethod());
         if (!$result) {


### PR DESCRIPTION
The current implementation tries to use startls instead of tls.

This is incorrect because
 - starttls: opens a tcp connection and later upgrades to tls
 - tls: opens the tls connection and does not need to upgrade later