### PR TITLE
Query::chunked does not loop over the last chunk

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -381,11 +381,13 @@ class Query {
 
             $this->limit = $chunk_size;
             $this->page = $start_chunk;
+            $handled_messages_count = 0;
             do {
                 $messages = $this->populate($available_messages);
+                $handled_messages_count += $messages->count();
                 $callback($messages, $this->page);
                 $this->page++;
-            } while ($this->limit * $this->page <= $available_messages_count);
+            } while ($handled_messages_count < $available_messages_count);
             $this->limit = $old_limit;
             $this->page = $old_page;
         }


### PR DESCRIPTION
When using Query::chunked over a large number of emails the last chunk is not being populate and passed to the callback method.

The `while ($this->limit * $this->page <= $available_messages_count);` doesn't properly works

With `$available_messages_count = 15` and `$this->limit = 10;`, at the end of first iteration, when testing while conditon: `$this->page = 2` so `$this->limit * $this->page = 20` and `20 > $available_messages_count` and the loop stops.

Simplified original version
```php
        $callback = function($messages, $page) {
            var_dump($messages);
        };

        $available_messages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
        $available_messages_count = count($available_messages);
        $limit = 10;
        $page = 1;
        do {
            $messages = array_slice($available_messages, ($page - 1) * $limit, $limit, true);
            $callback($messages, $page);
            $page++;
        } while ($limit * $page <= $available_messages_count);
        
/*
Does only one loop over the first  messages and stops
array(10) {
  [0]=>
  int(1)
  [1]=>
  int(2)
  [2]=>
  int(3)
  [3]=>
  int(4)
  [4]=>
  int(5)
  [5]=>
  int(6)
  [6]=>
  int(7)
  [7]=>
  int(8)
  [8]=>
  int(9)
  [9]=>
  int(10)
}
*/
```

Proposed solution:
```php
        $callback = function($messages, $page) {
            var_dump($messages);
        };

        $available_messages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
        $available_messages_count = count($available_messages);
        $limit = 10;
        $page = 1;
        $handled_messages_count = 0;
        do {
            $messages = array_slice($available_messages, ($page - 1) * $limit, $limit, true);
            $handled_messages_count += count($messages); // Can be equal OR less than $limit (in the last iteration)
            $callback($messages, $page);
            $page++;
        } while ($handled_messages_count < $available_messages_count); // No or equal here cause it would endup in an infinit loop
        
/*
array(10) {
  [0]=>
  int(1)
  [1]=>
  int(2)
  [2]=>
  int(3)
  [3]=>
  int(4)
  [4]=>
  int(5)
  [5]=>
  int(6)
  [6]=>
  int(7)
  [7]=>
  int(8)
  [8]=>
  int(9)
  [9]=>
  int(10)
}
array(5) {
  [10]=>
  int(11)
  [11]=>
  int(12)
  [12]=>
  int(13)
  [13]=>
  int(14)
  [14]=>
  int(15)
}
*/
```

