### PR TITLE
add search method for messages with UID greater than X

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -476,6 +476,40 @@ class Query {
     }
 
     /**
+     * Get messages with UID greater than given UID.
+     *
+     * @param int|string $uid
+     *
+     * @return MessageCollection
+     * @throws ConnectionFailedException
+     * @throws EventNotFoundException
+     * @throws InvalidMessageDateException
+     * @throws MessageContentFetchingException
+     * @throws MessageFlagException
+     * @throws MessageHeaderFetchingException
+     * @throws MessageNotFoundException
+     * @throws RuntimeException
+     */
+    public function getMessagesGreaterThanUid($uid) {
+        $connection = $this->getClient()->getConnection();
+
+        $uids = $connection->getUid();
+        $ids = [];
+        $messages = MessageCollection::make([]);
+        foreach ($uids as $id) {
+            if ($id >= $uid) {
+                $ids[] = $id;
+
+                $messages->put("$id", $this->getMessageByUid($id));
+            }
+        }
+
+        $messages->total(count($ids));
+
+        return $messages;
+    }
+
+    /**
      * Don't mark messages as read when fetching
      *
      * @return $this


### PR DESCRIPTION
maybe fixed #200 

Hi @Webklex,

the `getMessagesGreaterThanUid` function searches for all messages that have a UID greater than or equal to the one passed. The found messages are initialized and returned as MessageCollection.

The proposed method is perhaps not the fastest, because each message is initialized individually. I took the foreach from the `ImapProtocol::overview` method and adapted it a bit.

I am also not sure if the `Query` class is the right place for the method. I didn't put the method in the `WhereQuery` class because it can't be linked to other conditions.

Example:
```php
/** @var Folder $inbox */
$inbox = $client->getFolderByName("INBOX");

$messages = $inbox->query()->getMessagesGreaterThanUid(1600);
```
It is important to note that the returned MessageColletion may or may not contain the passed UID. Depending on whether the UID is present on the server.

What do you think about the solution, @Webklex?