### PR TITLE
Fix return type in src/Client::createFolder() docblock

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -514,7 +514,7 @@ class Client {
      * @param string $folder
      * @param boolean $expunge
      *
-     * @return bool
+     * @return Folder
      * @throws ConnectionFailedException
      * @throws FolderFetchingException
      * @throws Exceptions\EventNotFoundException


### PR DESCRIPTION
Change return type of src/Client::createFolder() from 'bool' to 'Folder'