### PR TITLE
add uid cache for UID of a mailbox (folder) to improve performance

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -357,6 +357,10 @@ class Client {
             $this->connection->enableDebug();
         }
 
+        if (!ClientManager::get('options.uid_cache')) {
+            $this->connection->disableUidCache();
+        }
+
         try {
             $this->connection->connect($this->host, $this->port);
         } catch (ErrorException $e) {

--- a/src/Connection/Protocols/Protocol.php
+++ b/src/Connection/Protocols/Protocol.php
@@ -33,6 +33,11 @@ abstract class Protocol implements ProtocolInterface {
     protected $debug = false;
 
     /**
+     * @var boolean
+     */
+    protected $enable_uid_cache = true;
+
+    /**
      * @var false|resource
      */
     public $stream = false;
@@ -59,6 +64,13 @@ abstract class Protocol implements ProtocolInterface {
         'username' => null,
         'password' => null,
     ];
+
+    /**
+     * Cache for uid of active folder.
+     *
+     * @var null|array
+     */
+    protected $uid_cache = null;
 
     /**
      * Get an available cryptographic method
@@ -242,4 +254,32 @@ abstract class Protocol implements ProtocolInterface {
         return trim($this->getUIDKey($uid)." ".$command);
     }
 
+    /**
+     * Set the uid cache of current active folder
+     *
+     * @param array|null $uids
+     */
+    public function setUidCache($uids) {
+        if (is_null($uids)) {
+            $this->uid_cache = null;
+            return;
+        }
+
+        $messageNumber = 1;
+
+        $uid_cache = [];
+        foreach ($uids as $uid) {
+            $uid_cache[$messageNumber++] = $uid;
+        }
+
+        $this->uid_cache = $uid_cache;
+    }
+
+    public function enableUidCache() {
+        $this->enable_uid_cache = true;
+    }
+
+    public function disableUidCache() {
+        $this->enable_uid_cache = false;
+    }
 }

--- a/src/Connection/Protocols/ProtocolInterface.php
+++ b/src/Connection/Protocols/ProtocolInterface.php
@@ -13,6 +13,7 @@
 namespace Webklex\PHPIMAP\Connection\Protocols;
 
 use ErrorException;
+use Webklex\PHPIMAP\Client;
 use Webklex\PHPIMAP\Exceptions\AuthFailedException;
 use Webklex\PHPIMAP\Exceptions\ConnectionFailedException;
 use Webklex\PHPIMAP\Exceptions\InvalidMessageDateException;
@@ -392,4 +393,21 @@ interface ProtocolInterface {
      * Disable the debug mode
      */
     public function disableDebug();
+
+    /**
+     * Enable uid caching
+     */
+    public function enableUidCache();
+
+    /**
+     * Disable uid caching
+     */
+    public function disableUidCache();
+
+    /**
+     * Set the uid cache of current active folder
+     *
+     * @param array|null $uids
+     */
+    public function setUidCache($uids);
 }

--- a/src/config/imap.php
+++ b/src/config/imap.php
@@ -148,6 +148,7 @@ return [
         'soft_fail' => false,
         'rfc822' => true,
         'debug' => false,
+        'uid_cache' => true,
         'boundary' => '/boundary=(.*?(?=;)|(.*))/i',
         'message_key' => 'list',
         'fetch_order' => 'asc',


### PR DESCRIPTION
Hi @Webklex,

this PR adds a cache for UID of a mailbox (folder).

### Description

I noticed that when initializing each message, the `ProtocolInterface::getUid($id = null)` method is called. In this, the matching UID is to be found based on a message number. In the implementation of `ImapProtocol` the complete mailbox with all UIDs for each message is retrieved, iterated and searched for the matching message number and the stored UID. This causes not only a large additional effort in requests but also in the runtime of an execution.

For this problem I developed a UID cache, which writes the UIDs into an array at the first call of the `ProtocolInterface::getUid($id = null)`. If in a future query the mailbox (folder) has not changed, the cache is used. On logout or when the mailbox (folder) is changed, the cache is cleared.

You can disable the cache in the configuration (uid_cache). By default it is enabled.

### Tests

I have tried the cache on the following examples:
```php
$messages = $inbox->query()->whereSince(Carbon::create(2022, 1, 1))->get();
```

It found 133 messages.
If the UID cache is **deactivated** the call needs **17290ms**.
If the UID cache is **enabled** the call nedes **2211ms**.

If I have not miscalculated, that is a time saving of **87.21%**.

A second test with 100 messages:

```php
$messages = $inbox->query()->all()->limit(100)->get();
```
It found 311 in the mailbox but only 100 messages were initialized.
If the UID cache is **deactivated** the call needs **15201ms**.
If the UID cache is **enabled** the call needs **3621ms**.

That is a time saving of **76.18 %**.


### Potential problems:

1. The cache must be reset in additional locations.
2. I have not tested the LegacyProtocol.
3. The cache could become invalid during a fetch.
In the implementation of ImapProtocol, the cache is refreshed if no UID is found. Only after that an exception is thrown.

I hope the PR is helpful and I haven't missed anything. I am happy to receive feedback!
