### PR TITLE
Make package compatible with PHP 8.1

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -88,7 +88,7 @@ class Attribute implements ArrayAccess {
      * @param  mixed  $key
      * @return bool
      */
-    public function offsetExists($key) {
+    public function offsetExists($key): bool {
         return array_key_exists($key, $this->values);
     }
 
@@ -98,6 +98,7 @@ class Attribute implements ArrayAccess {
      * @param  mixed  $key
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key) {
         return $this->values[$key];
     }
@@ -109,7 +110,7 @@ class Attribute implements ArrayAccess {
      * @param  mixed  $value
      * @return void
      */
-    public function offsetSet($key, $value) {
+    public function offsetSet($key, $value): void {
         if (is_null($key)) {
             $this->values[] = $value;
         } else {
@@ -123,7 +124,7 @@ class Attribute implements ArrayAccess {
      * @param  string  $key
      * @return void
      */
-    public function offsetUnset($key) {
+    public function offsetUnset($key): void {
         unset($this->values[$key]);
     }
 

--- a/src/EncodingAliases.php
+++ b/src/EncodingAliases.php
@@ -473,8 +473,8 @@ class EncodingAliases {
      * @return string
      */
     public static function get($encoding, $fallback = null) {
-        if (isset(self::$aliases[strtolower($encoding)])) {
-            return self::$aliases[strtolower($encoding)];
+        if (isset(self::$aliases[strtolower($encoding ?? '')])) {
+            return self::$aliases[strtolower($encoding ?? '')];
         }
         return $fallback !== null ? $fallback : $encoding;
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -570,7 +570,7 @@ class Message {
                 $content = $this->convertEncoding($content, $encoding);
             }
 
-            $subtype = strtolower($part->subtype);
+            $subtype = strtolower($part->subtype ?? '');
             $subtype = $subtype == "plain" || $subtype == "" ? "text" : $subtype;
 
             if (isset($this->bodies[$subtype])) {
@@ -719,7 +719,7 @@ class Message {
         //     https://en.wikipedia.org/wiki/ASCII
         //
         // convertEncoding() function basically means convertToUtf8(), so when we convert ASCII string into UTF-8 it gets broken.
-        if (strtolower($from) == 'us-ascii' && $to == 'UTF-8') {
+        if (strtolower($from ?? '') == 'us-ascii' && $to == 'UTF-8') {
             return $str;
         }
 

--- a/src/Part.php
+++ b/src/Part.php
@@ -299,7 +299,7 @@ class Part {
      * @return bool
      */
     public function isAttachment(){
-        $valid_disposition = in_array(strtolower($this->disposition), ClientManager::get('options.dispositions'));
+        $valid_disposition = in_array(strtolower($this->disposition ?? ''), ClientManager::get('options.dispositions'));
 
         if ($this->type == IMAP::MESSAGE_TYPE_TEXT && ($this->ifdisposition == 0 || empty($this->disposition) || !$valid_disposition)) {
             if (($this->subtype == null || in_array((strtolower($this->subtype)), ["plain", "html"])) && $this->filename == null && $this->name == null) {


### PR DESCRIPTION
These changes make php-imap compatible with PHP 8.1

These changes apparently will make php-imap incompatible with PHP versions below PHP 7: https://www.tutorialspoint.com/php7/php7_returntype_declarations.htm

Extra info here: https://github.com/Webklex/php-imap/issues/212