### PR TITLE
fix UID cache issue

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -689,8 +689,8 @@ class ImapProtocol extends Protocol {
             $uids = $this->uid_cache;
         } else {
             try {
-                $uids = $this->fetch('UID', 1, INF);
-                $this->setUidCache($uids); // set cache for this folder
+                $this->setUidCache($this->fetch('UID', 1, INF)); // set cache for this folder
+                $uids = $this->uid_cache;
             } catch (RuntimeException $e) {}
         }
 

--- a/src/Connection/Protocols/LegacyProtocol.php
+++ b/src/Connection/Protocols/LegacyProtocol.php
@@ -288,7 +288,7 @@ class LegacyProtocol extends Protocol {
             }
 
             $this->setUidCache($uids);
-            return $uids;
+            return $this->uid_cache;
         }
 
         return \imap_uid($this->stream, $id);


### PR DESCRIPTION
fix #218 

As identified by @ellisonpatterson is an error in the return of the UIDs. When `uid_cache` is disabled, a different array structure is returned than when cache is enabled.

This is because during the `setUidCache` method the array is modified.

In this fix the `uid_cache` is set and returned directly. Previously a local variable was returned from the `getUID()` method.

The change was also implemented in the `LegacyProtocol`. However, this has not yet been tested.