### PR TITLE
Fix problem with illegal offset error.

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -578,7 +578,7 @@ class ImapProtocol extends Protocol {
                     $uidKey = 1;
                 } else {
                     $found = array_search('UID', $tokens[2]);
-                    if (!$found) {
+                    if ($found === false || $found === -1) {
                         continue;
                     }
 

--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -577,7 +577,12 @@ class ImapProtocol extends Protocol {
                 } else if ($tokens[2][0] == 'UID') {
                     $uidKey = 1;
                 } else {
-                    $uidKey = array_search('UID', $tokens[2]) + 1;
+                    $found = array_search('UID', $tokens[2]);
+                    if (!$found) {
+                        continue;
+                    }
+
+                    $uidKey = $found + 1;
                 }
             }
 


### PR DESCRIPTION
Fixed #224, #98.

Hello @Webklex!
I've recently got stuck on a problem with the "illegal offset" error while using your package. After debugging and lots of tests performed on real mailboxes, I realized that we have to remove not-message entries from the results array - because these rows don't have a UID field. The `array_search` can return `false` or `-1` when can't find searched value.
In our case, the `array_search` returns `-1`  or (mainly) `false` as output, and then, the script was trying to add `1` to the result. In PHP `false + 1 = 1`.

So when the algorithm hadn't been able to find the UID value it thought, that the proper index is 1 (as a result of the `false + 1` calculation), which was causing the error.