### PR TITLE
Fix imap_reopen folder argument

### DIFF
--- a/src/Connection/Protocols/LegacyProtocol.php
+++ b/src/Connection/Protocols/LegacyProtocol.php
@@ -181,7 +181,7 @@ class LegacyProtocol extends Protocol {
      * @throws RuntimeException
      */
     public function selectFolder(string $folder = 'INBOX') {
-        \imap_reopen($this->stream, $folder, IMAP::OP_READONLY, 3);
+        \imap_reopen($this->stream, $this->getAddress().$folder, IMAP::OP_READONLY, 3);
         $this->uid_cache = null;
         return $this->examineFolder($folder);
     }


### PR DESCRIPTION
imap_reopen as imap_open requires folder argument to start with the bracket, ie address