### PR TITLE
Fix multiline header unfolding

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -242,7 +242,7 @@ class Header {
                 $imap_headers[$key] = $values;
             }
         }
-        $lines = explode("\r\n", str_replace("\r\n\t", ' ', $raw_headers));
+        $lines = explode("\r\n", preg_replace("/\r\n\s*/", ' ', $raw_headers));
         $prev_header = null;
         foreach ($lines as $line) {
             if (substr($line, 0, 1) === "\n") {


### PR DESCRIPTION
According to rfc 822 **3.1.1. Long Header Fields**, the multiple-line "folding" is properly unfolded by "regarding CRLF immediately followed by a LWSP-char", meaning it is not limited to `\t`. 

https://datatracker.ietf.org/doc/html/rfc822

