### PR TITLE
MessageCollection instead of array given

### DIFF
--- a/src/Support/PaginatedCollection.php
+++ b/src/Support/PaginatedCollection.php
@@ -44,7 +44,7 @@ class PaginatedCollection extends Collection {
 
         $total = $this->total ?: $this->count();
 
-        $results = !$prepaginated && $total ? $this->forPage($page, $per_page) : $this->all();
+        $results = !$prepaginated && $total ? $this->forPage($page, $per_page)->toArray() : $this->all();
 
         return $this->paginator($results, $total, $per_page, $page, [
             'path'      => Paginator::resolveCurrentPath(),


### PR DESCRIPTION
Hello @Webklex,

the return value of _forPage()_ was not an array, but the function call below require that _$results_ is an array.

```
In PaginatedCollection.php line 65:
                                                                                                             
  Webklex\PHPIMAP\Support\PaginatedCollection::paginator(): Argument #1 ($items) must be of type array, Web  
  klex\PHPIMAP\Support\MessageCollection given, called in /.../vendor/webklex/php-i  
  map/src/Support/PaginatedCollection.php on line 51 
```

Best regards,
Roger