### PR TITLE
Fix empty response error for blank lines

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -108,7 +108,7 @@ class ImapProtocol extends Protocol {
         while (($next_char = fread($this->stream, 1)) !== false && $next_char !== "\n") {
             $line .= $next_char;
         }
-        if ($line === "") {
+        if ($line === "" && $next_char !== "\n") {
             throw new RuntimeException('empty response');
         }
         if ($this->debug) echo "<< ".$line."\n";


### PR DESCRIPTION
If a blank line exists somewhere in the middle of a message it is throwing an `empty response` exception. A blank line is OK in the middle of a message and does not indicate a problem when a `\n` was properly found as the next character, since the stream is still open and reading fine.
