### PR TITLE
Disabled not necessary msgno getting procedure.

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -1372,7 +1372,6 @@ class Message {
      */
     public function setUid(int $uid): Message {
         $this->uid = $uid;
-        $this->msgn = $this->client->getConnection()->getMessageNumber($this->uid);
         $this->msglist = null;
 
         return $this;


### PR DESCRIPTION
Hi @Webklex 

I've increased the performance of message fetching procedure.
In the `setUid` method was (from my point of view) not necessary line getting `msgno`.
So I decided to remove it - because when we get messages via UID (and it's been checked before, e.g. in `setSequenceId()`), there is no need in using `msgno`. Could you validate whether it makes sense?

Result: (in my case) reduced 6 seconds to 0.8s

Greetings!