### PR TITLE
fix assumedNextTaggedLine bug

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -150,7 +150,7 @@ class ImapProtocol extends Protocol {
      */
     protected function assumedNextTaggedLine(string $start, &$tag): bool {
         $line = $this->nextTaggedLine($tag);
-        return strpos($line, $start) >= 0;
+        return strpos($line, $start) !== false;
     }
 
     /**


### PR DESCRIPTION
fix assumedNextTaggedLine bug
The session expiration error returned by the done command is not captured correctly, resulting in laravel command mode not receiving new emails after some time.