### PR TITLE
Fix undefined attachment name when headers use "filename*=" format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [UNRELEASED]
 ### Fixed
-- NaN
+- Fix undefined attachment name when headers use "filename*=" format
 
 ### Added
 - NaN

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/pagination": ">=5.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -8,23 +9,25 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+        </report>
+    </coverage>
     <testsuites>
         <testsuite name="PHP-IMAP Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
     <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
     <php>
         <env name="APP_ENV" value="testing"/>

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests;
+
+use Webklex\PHPIMAP\Header;
+use PHPUnit\Framework\TestCase;
+
+class HeaderTest extends TestCase
+{
+    public function testRfc822ParseHeaders()
+    {
+        $mock = $this->getMockBuilder(Header::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $config = new \ReflectionProperty($mock, 'config');
+        $config->setValue($mock, ['rfc822' => true]);
+
+        $mockHeader = "Content-Type: text/csv; charset=WINDOWS-1252;  name*0=\"TH_Is_a_F ile name example 20221013.c\"; name*1=sv\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Disposition: attachment; filename*0=\"TH_Is_a_F ile name example 20221013.c\"; filename*1=\"sv\"\r\n";
+
+        $expected = new \stdClass();
+        $expected->content_type = 'text/csv; charset=WINDOWS-1252;  name*0="TH_Is_a_F ile name example 20221013.c"; name*1=sv';
+        $expected->content_transfer_encoding = 'quoted-printable';
+        $expected->content_disposition = 'attachment; filename*0="TH_Is_a_F ile name example 20221013.c"; filename*1="sv"';
+
+        $this->assertEquals($expected, $mock->rfc822_parse_headers($mockHeader));
+    }
+
+    public function testExtractHeaderExtensions()
+    {
+        $mock = $this->getMockBuilder(Header::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $method = new \ReflectionMethod($mock, 'extractHeaderExtensions');
+        $method->setAccessible(true);
+
+        $mockAttributes = [
+            'content_type' => 'text/csv; charset=WINDOWS-1252;  name*0="TH_Is_a_F ile name example 20221013.c"; name*1=sv',
+            'content_transfer_encoding' => 'quoted-printable',
+            'content_disposition' => 'attachment; filename*0="TH_Is_a_F ile name example 20221013.c"; filename*1="sv"; attribute_test=attribute_test_value',
+        ];
+
+        $attributes = new \ReflectionProperty($mock, 'attributes');
+        $attributes->setValue($mock, $mockAttributes);
+
+        $method->invoke($mock);
+
+        $this->assertArrayHasKey('filename', $mock->getAttributes());
+        $this->assertArrayNotHasKey('filename*0', $mock->getAttributes());
+        $this->assertEquals('TH_Is_a_F ile name example 20221013.csv', $mock->get('filename'));
+
+        $this->assertArrayHasKey('name', $mock->getAttributes());
+        $this->assertArrayNotHasKey('name*0', $mock->getAttributes());
+        $this->assertEquals('TH_Is_a_F ile name example 20221013.csv', $mock->get('name'));
+
+        $this->assertArrayHasKey('content_type', $mock->getAttributes());
+        $this->assertEquals('text/csv', $mock->get('content_type'));
+
+        $this->assertArrayHasKey('charset', $mock->getAttributes());
+        $this->assertEquals('WINDOWS-1252', $mock->get('charset'));
+
+        $this->assertArrayHasKey('content_transfer_encoding', $mock->getAttributes());
+        $this->assertEquals('quoted-printable', $mock->get('content_transfer_encoding'));
+
+        $this->assertArrayHasKey('content_disposition', $mock->getAttributes());
+        $this->assertEquals('attachment', $mock->get('content_disposition'));
+        $this->assertEquals('quoted-printable', $mock->get('content_transfer_encoding'));
+
+        $this->assertArrayHasKey('attribute_test', $mock->getAttributes());
+        $this->assertEquals('attribute_test_value', $mock->get('attribute_test'));
+    }
+}


### PR DESCRIPTION
Hello,

A little PR as a first step to fix attachment names being set as "undefined" if the header uses the format "filename*=".
I've also added some unit tests to cover the change I made (and updated to phpunit version).

Feel free to review it and drop any comments :)