### PR TITLE
Fix #306 Folder name encoding error in appendMessage()

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -291,7 +291,7 @@ class Folder {
             $internal_date = $internal_date->format('d-M-Y H:i:s O');
         }
 
-        return $this->client->getConnection()->appendMessage($this->full_name, $message, $options, $internal_date);
+        return $this->client->getConnection()->appendMessage($this->path, $message, $options, $internal_date);
     }
 
     /**


### PR DESCRIPTION
Create a folder containing a special character e.g. 'sent & trash'.
Then add a message to that folder.

$client->connect();
$folder = $client->getFolder('sent & trash');
$folder->appendMessage($message); // Not working, showing error

ERROR:
`failed to send literal string.`
`TAG3 APPEND "INBOX.sent & trash" `  The folder name should be UTF7-IMAP.

In the appendMessage () function, changing `$this->full_name` to` $this->path` solves the problem.