### PR TITLE
Prevent infinite loop

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -169,6 +169,7 @@ class ImapProtocol extends Protocol {
         while (($pos = strpos($line, ' ')) !== false) {
             $token = substr($line, 0, $pos);
             if (!strlen($token)) {
+                $line = substr($line, $pos + 1);
                 continue;
             }
             while ($token[0] == '(') {


### PR DESCRIPTION
A leading whitespace or multiple whitespaces causes an infitnite loop.