### PR TITLE
Fix for extension recognition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-iconv": "*",
         "ext-fileinfo": "*",
         "nesbot/carbon": ">=1.0",
-        "symfony/http-foundation": ">=2.8.0",
+        "symfony/mime": "^4.3 || ^5.0 || ^6.0",
         "illuminate/pagination": ">=5.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,14 @@
         "ext-iconv": "*",
         "ext-fileinfo": "*",
         "nesbot/carbon": ">=1.0",
-        "symfony/mime": "^4.3 || ^5.0 || ^6.0",
+        "symfony/http-foundation": ">=2.8.0",
         "illuminate/pagination": ">=5.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"
+    },
+    "suggest": {
+        "symfony/mime": "Recomended for better extension support"
     },
     "autoload": {
         "psr-4": {

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -13,7 +13,6 @@
 namespace Webklex\PHPIMAP;
 
 use Illuminate\Support\Str;
-use Symfony\Component\Mime\MimeTypes;
 use Webklex\PHPIMAP\Exceptions\MaskNotFoundException;
 use Webklex\PHPIMAP\Exceptions\MethodNotFoundException;
 use Webklex\PHPIMAP\Support\Masks\AttachmentMask;
@@ -279,8 +278,20 @@ class Attachment {
      * @return string|null
      */
     public function getExtension(){
-        $extensions = MimeTypes::getDefault()->getExtensions($this->getMimeType());
-        return $extensions[0] ?? null;
+        $guesser = "\Symfony\Component\Mime\MimeTypes";
+        if (class_exists($guesser) !== false) {
+            /** @var Symfony\Component\Mime\MimeTypes $guesser */
+            $extensions = $guesser::getDefault()->getExtensions($this->getMimeType());
+            return $extensions[0] ?? null;
+        }
+
+        $deprecated_guesser = "\Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser";
+        if (class_exists($deprecated_guesser) !== false){
+            /** @var \Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser $deprecated_guesser */
+            return $deprecated_guesser::getInstance()->guess($this->getMimeType());
+        }
+
+        return null;
     }
 
     /**

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -13,6 +13,7 @@
 namespace Webklex\PHPIMAP;
 
 use Illuminate\Support\Str;
+use Symfony\Component\Mime\MimeTypes;
 use Webklex\PHPIMAP\Exceptions\MaskNotFoundException;
 use Webklex\PHPIMAP\Exceptions\MethodNotFoundException;
 use Webklex\PHPIMAP\Support\Masks\AttachmentMask;
@@ -278,14 +279,7 @@ class Attachment {
      * @return string|null
      */
     public function getExtension(){
-        $deprecated_guesser = "\Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser";
-        if (class_exists($deprecated_guesser) !== false){
-            /** @var \Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser $deprecated_guesser */
-            return $deprecated_guesser::getInstance()->guess($this->getMimeType());
-        }
-        $guesser = "\Symfony\Component\Mime\MimeTypes";
-        /** @var Symfony\Component\Mime\MimeTypes $guesser */
-        $extensions = $guesser::getDefault()->getExtensions($this->getMimeType());
+        $extensions = MimeTypes::getDefault()->getExtensions($this->getMimeType());
         return $extensions[0] ?? null;
     }
 


### PR DESCRIPTION
Related to https://github.com/Webklex/php-imap/issues/323:
- Fix for `symfony/http-foundation` >= 5.0.0 & not installed `symfony/mime`
- Use of `\Symfony\Component\Mime\MimeTypes` as default guesser if possible
- Suggestion to use `symfony/mime`