### PR TITLE
Use message timestamp when parsing date fails

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -740,8 +740,10 @@ class Header {
                 }
                 try {
                     $parsed_date = Carbon::parse($date);
-                } catch (\Exception $_e) {
-                    if (!isset($this->config["fallback_date"])) {
+                } catch (\Exception $_e) {                    
+                    if (property_exists($header, 'udate')) {
+                        $parsed_date = Carbon::createFromTimestamp($header->udate);
+                    } elseif (!isset($this->config["fallback_date"])) {
                         throw new InvalidMessageDateException("Invalid message date. ID:" . $this->get("message_id") . " Date:" . $header->date . "/" . $date, 1100, $e);
                     } else {
                         $parsed_date = Carbon::parse($this->config["fallback_date"]);


### PR DESCRIPTION
I think we should take the timestamp from the message header "udate" and use it as a fallback, when PHP DateTime does not recognize the date format. I had at least one case where a german localized "date" header could not be parsed.

The only thing that gets lost is the information on the timezone, which I don't think ist such an important feature. Or is there something I am missing?