### PR TITLE
Fix use of ST_MSGN as sequence method

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -644,7 +644,7 @@ class ImapProtocol extends Protocol {
             $data = [];
 
             // find array key of UID value; try the last elements, or search for it
-            if ($uid) {
+            if ($uid === IMAP::ST_UID) {
                 $count = count($tokens[2]);
                 if ($tokens[2][$count - 2] == 'UID') {
                     $uidKey = $count - 1;
@@ -661,7 +661,7 @@ class ImapProtocol extends Protocol {
             }
 
             // ignore other messages
-            if ($to === null && !is_array($from) && ($uid ? $tokens[2][$uidKey] != $from : $tokens[0] != $from)) {
+            if ($to === null && !is_array($from) && ($uid === IMAP::ST_UID ? $tokens[2][$uidKey] != $from : $tokens[0] != $from)) {
                 continue;
             }
 
@@ -669,7 +669,7 @@ class ImapProtocol extends Protocol {
             if (count($items) == 1) {
                 if ($tokens[2][0] == $items[0]) {
                     $data = $tokens[2][1];
-                } elseif ($uid && $tokens[2][2] == $items[0]) {
+                } elseif ($uid === IMAP::ST_UID && $tokens[2][2] == $items[0]) {
                     $data = $tokens[2][3];
                 } else {
                     $expectedResponse = 0;
@@ -696,12 +696,12 @@ class ImapProtocol extends Protocol {
             }
 
             // if we want only one message we can ignore everything else and just return
-            if ($to === null && !is_array($from) && ($uid ? $tokens[2][$uidKey] == $from : $tokens[0] == $from)) {
+            if ($to === null && !is_array($from) && ($uid === IMAP::ST_UID ? $tokens[2][$uidKey] == $from : $tokens[0] == $from)) {
                 // we still need to read all lines
                 while (!$this->readLine($response, $tokens, $tag))
                     return $response->setResult($data);
             }
-            if ($uid) {
+            if ($uid === IMAP::ST_UID) {
                 $result[$tokens[2][$uidKey]] = $data;
             } else {
                 $result[$tokens[0]] = $data;
@@ -1227,7 +1227,7 @@ class ImapProtocol extends Protocol {
         $response = $this->getUid();
         $ids = [];
         foreach ($response->data() as $msgn => $v) {
-            $id = $uid ? $v : $msgn;
+            $id = $uid === IMAP::ST_UID ? $v : $msgn;
             if (($to >= $id && $from <= $id) || ($to === "*" && $from <= $id)) {
                 $ids[] = $id;
             }

--- a/src/Connection/Protocols/LegacyProtocol.php
+++ b/src/Connection/Protocols/LegacyProtocol.php
@@ -253,7 +253,7 @@ class LegacyProtocol extends Protocol {
             $uids = is_array($uids) ? $uids : [$uids];
             foreach ($uids as $id) {
                 $response->addCommand("imap_fetchbody");
-                $result[$id] = \imap_fetchbody($this->stream, $id, "", $uid ? IMAP::ST_UID : IMAP::NIL);
+                $result[$id] = \imap_fetchbody($this->stream, $id, "", $uid === IMAP::ST_UID ? IMAP::ST_UID : IMAP::NIL);
             }
 
             return $result;

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -295,7 +295,7 @@ class Folder {
     public function overview(string $sequence = null): array {
         $this->client->openFolder($this->path);
         $sequence = $sequence === null ? "1:*" : $sequence;
-        $uid = ClientManager::get('options.sequence', IMAP::ST_MSGN) == IMAP::ST_UID;
+        $uid = ClientManager::get('options.sequence', IMAP::ST_MSGN);
         $response = $this->client->getConnection()->overview($sequence, $uid);
         return $response->validatedData();
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -495,7 +495,7 @@ class Message {
      */
     private function parseHeader(): void {
         $sequence_id = $this->getSequenceId();
-        $headers = $this->client->getConnection()->headers([$sequence_id], "RFC822", $this->sequence === IMAP::ST_UID)->validatedData();
+        $headers = $this->client->getConnection()->headers([$sequence_id], "RFC822", $this->sequence)->validatedData();
         if (!isset($headers[$sequence_id])) {
             throw new MessageHeaderFetchingException("no headers found", 0);
         }
@@ -548,7 +548,7 @@ class Message {
 
         $sequence_id = $this->getSequenceId();
         try {
-            $flags = $this->client->getConnection()->flags([$sequence_id], $this->sequence === IMAP::ST_UID)->validatedData();
+            $flags = $this->client->getConnection()->flags([$sequence_id], $this->sequence)->validatedData();
         } catch (Exceptions\RuntimeException $e) {
             throw new MessageFlagException("flag could not be fetched", 0, $e);
         }
@@ -578,7 +578,7 @@ class Message {
 
         $sequence_id = $this->getSequenceId();
         try {
-            $contents = $this->client->getConnection()->content([$sequence_id], "RFC822", $this->sequence === IMAP::ST_UID)->validatedData();
+            $contents = $this->client->getConnection()->content([$sequence_id], "RFC822", $this->sequence)->validatedData();
         } catch (Exceptions\RuntimeException $e) {
             throw new MessageContentFetchingException("failed to fetch content", 0);
         }
@@ -1008,7 +1008,7 @@ class Message {
             $folder = $this->client->getFolderByPath($folder_path);
 
             $this->client->openFolder($this->folder_path);
-            if ($this->client->getConnection()->copyMessage($folder->path, $this->getSequenceId(), null, $this->sequence === IMAP::ST_UID)->validatedData()) {
+            if ($this->client->getConnection()->copyMessage($folder->path, $this->getSequenceId(), null, $this->sequence)->validatedData()) {
                 return $this->fetchNewMail($folder, $next_uid, "copied", $expunge);
             }
         }
@@ -1047,7 +1047,7 @@ class Message {
             $folder = $this->client->getFolderByPath($folder_path);
 
             $this->client->openFolder($this->folder_path);
-            if ($this->client->getConnection()->moveMessage($folder->path, $this->getSequenceId(), null, $this->sequence === IMAP::ST_UID)->validatedData()) {
+            if ($this->client->getConnection()->moveMessage($folder->path, $this->getSequenceId(), null, $this->sequence)->validatedData()) {
                 return $this->fetchNewMail($folder, $next_uid, "moved", $expunge);
             }
         }
@@ -1172,7 +1172,7 @@ class Message {
         $flag = "\\" . trim(is_array($flag) ? implode(" \\", $flag) : $flag);
         $sequence_id = $this->getSequenceId();
         try {
-            $status = $this->client->getConnection()->store([$flag], $sequence_id, $sequence_id, "+", true, $this->sequence === IMAP::ST_UID)->validatedData();
+            $status = $this->client->getConnection()->store([$flag], $sequence_id, $sequence_id, "+", true, $this->sequence)->validatedData();
         } catch (Exceptions\RuntimeException $e) {
             throw new MessageFlagException("flag could not be set", 0, $e);
         }
@@ -1204,7 +1204,7 @@ class Message {
         $flag = "\\" . trim(is_array($flag) ? implode(" \\", $flag) : $flag);
         $sequence_id = $this->getSequenceId();
         try {
-            $status = $this->client->getConnection()->store([$flag], $sequence_id, $sequence_id, "-", true, $this->sequence === IMAP::ST_UID)->validatedData();
+            $status = $this->client->getConnection()->store([$flag], $sequence_id, $sequence_id, "-", true, $this->sequence)->validatedData();
         } catch (Exceptions\RuntimeException $e) {
             throw new MessageFlagException("flag could not be removed", 0, $e);
         }


### PR DESCRIPTION
When we upgraded from version 2.7.2 to 4.1.0 of this library we noticed bugs and sneaky behaviours using the sequence method ST_MSGN.
We think that these two issues suffered the same behaviours that we noticed:
- #341
- https://github.com/Webklex/laravel-imap/issues/454

We checked the differences among old version and new version. We found that the main issue regards the use of the $uid variable in the "fetch" method of the ImapProtocol class. The old version used that variable as a boolean while the new code treats it sometimes as bool and sometimes as int|string. 

This pull request restored the old behaviour and with these changes we can see our code started work again.
Can you please check it and understand if you want to merged it in the master branch?