### PR TITLE
remove inline from options.dispositions

### DIFF
--- a/src/config/imap.php
+++ b/src/config/imap.php
@@ -155,7 +155,7 @@ return [
         'boundary' => '/boundary=(.*?(?=;)|(.*))/i',
         'message_key' => 'list',
         'fetch_order' => 'asc',
-        'dispositions' => ['attachment', 'inline'],
+        'dispositions' => ['attachment'],
         'common_folders' => [
             "root" => "INBOX",
             "junk" => "INBOX/Junk",


### PR DESCRIPTION
Hey,

I was not able to retrieve a text/html body without removing `inline` from this configuration option.
With inline removed, `\Webklex\PHPIMAP\Message::fetchPart` is now able to extract/parse the bodies.

FYI here is the dump output for the `$raw_structure` of my message:
```
^ """
--63c14a61_e26858d_3e0\r\n
Content-Type: text/plain; charset="utf-8"\r\n
Content-Transfer-Encoding: quoted-printable\r\n
Content-Disposition: inline\r\n
\r\n
TEXT BODY
\r\n
Regards\r\n
--63c14a61_e26858d_3e0\r\n
Content-Type: text/html; charset="utf-8"\r\n
Content-Transfer-Encoding: quoted-printable\r\n
Content-Disposition: inline\r\n
\r\n
<html>HTML BODY</html>\r\n
--63c14a61_e26858d_3e0--\r\n
\r\n
"""
```

This may fix the following issues:
- https://github.com/Webklex/php-imap/issues/336
- https://github.com/Webklex/php-imap/issues/329
- https://github.com/Webklex/php-imap/issues/275
- https://github.com/Webklex/php-imap/issues/245
- https://github.com/Webklex/php-imap/issues/142