### PR TITLE
Not all attachments are pushed to the collection

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -701,7 +701,7 @@ class Message {
         $oAttachment = new Attachment($this, $part);
 
         if ($oAttachment->getName() !== null && $oAttachment->getSize() > 0) {
-            if ($oAttachment->getId() !== null) {
+            if ($oAttachment->getId() !== null && $this->attachments->offsetExists($oAttachment->getId())) {
                 $this->attachments->put($oAttachment->getId(), $oAttachment);
             } else {
                 $this->attachments->push($oAttachment);


### PR DESCRIPTION
I have a problem with fetching all attachments from the email (v4 - I don't know abount other versions). In example I have 7 attachments on the email, but randomly getting 5 or 6 attachments. I don't know, maybe problem is with text attachments, because I have a problem only with text attachments, but this patch solvs the problem. I can't reproduce this problem and can't share my issue, because it is private data. You can try to get email message with 10 attachments with different types, maybe you will reproduce it. Is possible to fast merge this pull request?

There is a hotfix and tag for v4 which I using in project to solve this problem https://github.com/AdrianKuriata/php-imap/tree/4.1.2-hotfix https://github.com/AdrianKuriata/php-imap/tree/4.1.2.2