### PR TITLE
Make the space optional after a comma separator

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -510,7 +510,7 @@ class Header {
         }
 
         foreach ($values as $address) {
-            foreach (preg_split('/, (?=(?:[^"]*"[^"]*")*[^"]*$)/', $address) as $split_address) {
+            foreach (preg_split('/, ?(?=(?:[^"]*"[^"]*")*[^"]*$)/', $address) as $split_address) {
                 $split_address = trim(rtrim($split_address));
 
                 if (strpos($split_address, ",") == strlen($split_address) - 1) {


### PR DESCRIPTION
I'm seeing that sometimes the TO addresses are only separated by a comma, instead of a comma and space.
Adding this question mark still allows for 1 space, which fixes the problem for me, but I wonder if the space should be removed entirely.