### PR TITLE
Better connection check for IMAP

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -91,6 +91,24 @@ class ImapProtocol extends Protocol {
     }
 
     /**
+     * Check if the current session is connected
+     *
+     * @return bool
+     */
+    public function connected(): bool {
+        if ((bool)$this->stream) {
+            try {
+                $this->requestAndResponse('NOOP');
+                return true;
+            }
+            catch (ImapServerErrorException|RuntimeException) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Enable tls on the current connection
      *
      * @throws ConnectionFailedException


### PR DESCRIPTION
Normally the Protocol class only checks if the stream has been created:
`return (bool)$this->stream;`
But sometimes (we have many clients and transactions) the PHP stream is TRUE even though the connection has been lost. We have tested to send the simple command "NOOP" to check if the connection is really up and have a lot less "empty response" errors in our logs. I have not found a better way to do this.