### PR TITLE
Fix bug when multipart message getHTMLBody() method returns null

### DIFF
--- a/src/Structure.php
+++ b/src/Structure.php
@@ -112,7 +112,11 @@ class Structure {
 
         $headers = new Header($headers);
         if (($boundary = $headers->getBoundary()) !== null) {
-            return $this->detectParts($boundary, $body, $part_number);
+            $parts = $this->detectParts($boundary, $body, $part_number);
+
+            if(count($parts) > 1) {
+                return $parts;
+            }
         }
 
         return [new Part($body, $headers, $part_number)];


### PR DESCRIPTION
This bug occurs when the recursively detected parts are fewer than 2. After making this change, the HTML body is properly loaded by this method.