### PR TITLE
Fix: Improve return type hints and return docblocks for query classes

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -640,7 +640,7 @@ class Query {
      *
      * @return $this
      */
-    public function leaveUnread(): Query {
+    public function leaveUnread(): static {
         $this->setFetchOptions(IMAP::FT_PEEK);
 
         return $this;
@@ -651,7 +651,7 @@ class Query {
      *
      * @return $this
      */
-    public function markAsRead(): Query {
+    public function markAsRead(): static {
         $this->setFetchOptions(IMAP::FT_UID);
 
         return $this;
@@ -663,7 +663,7 @@ class Query {
      *
      * @return $this
      */
-    public function setSequence(int $sequence): Query {
+    public function setSequence(int $sequence): static {
         $this->sequence = $sequence;
 
         return $this;
@@ -699,7 +699,7 @@ class Query {
      *
      * @return $this
      */
-    public function limit(int $limit, int $page = 1): Query {
+    public function limit(int $limit, int $page = 1): static {
         if ($page >= 1) $this->page = $page;
         $this->limit = $limit;
 
@@ -719,9 +719,9 @@ class Query {
      * Set all query parameters
      * @param array $query
      *
-     * @return Query
+     * @return $this
      */
-    public function setQuery(array $query): Query {
+    public function setQuery(array $query): static {
         $this->query = new Collection($query);
         return $this;
     }
@@ -739,9 +739,9 @@ class Query {
      * Set the raw query
      * @param string $raw_query
      *
-     * @return Query
+     * @return $this
      */
-    public function setRawQuery(string $raw_query): Query {
+    public function setRawQuery(string $raw_query): static {
         $this->raw_query = $raw_query;
         return $this;
     }
@@ -759,9 +759,9 @@ class Query {
      * Set all extensions that should be used
      * @param string[] $extensions
      *
-     * @return Query
+     * @return $this
      */
-    public function setExtensions(array $extensions): Query {
+    public function setExtensions(array $extensions): static {
         $this->extensions = $extensions;
         if (count($this->extensions) > 0) {
             if (in_array("UID", $this->extensions) === false) {
@@ -775,9 +775,9 @@ class Query {
      * Set the client instance
      * @param Client $client
      *
-     * @return Query
+     * @return $this
      */
-    public function setClient(Client $client): Query {
+    public function setClient(Client $client): static {
         $this->client = $client;
         return $this;
     }
@@ -795,9 +795,9 @@ class Query {
      * Set the fetch limit
      * @param int $limit
      *
-     * @return Query
+     * @return $this
      */
-    public function setLimit(int $limit): Query {
+    public function setLimit(int $limit): static {
         $this->limit = $limit <= 0 ? null : $limit;
         return $this;
     }
@@ -815,9 +815,9 @@ class Query {
      * Set the page
      * @param int $page
      *
-     * @return Query
+     * @return $this
      */
-    public function setPage(int $page): Query {
+    public function setPage(int $page): static {
         $this->page = $page;
         return $this;
     }
@@ -826,9 +826,9 @@ class Query {
      * Set the fetch option flag
      * @param int $fetch_options
      *
-     * @return Query
+     * @return $this
      */
-    public function setFetchOptions(int $fetch_options): Query {
+    public function setFetchOptions(int $fetch_options): static {
         $this->fetch_options = $fetch_options;
         return $this;
     }
@@ -837,9 +837,9 @@ class Query {
      * Set the fetch option flag
      * @param int $fetch_options
      *
-     * @return Query
+     * @return $this
      */
-    public function fetchOptions(int $fetch_options): Query {
+    public function fetchOptions(int $fetch_options): static {
         return $this->setFetchOptions($fetch_options);
     }
 
@@ -865,9 +865,9 @@ class Query {
      * Set the fetch body flag
      * @param boolean $fetch_body
      *
-     * @return Query
+     * @return $this
      */
-    public function setFetchBody(bool $fetch_body): Query {
+    public function setFetchBody(bool $fetch_body): static {
         $this->fetch_body = $fetch_body;
         return $this;
     }
@@ -876,9 +876,9 @@ class Query {
      * Set the fetch body flag
      * @param boolean $fetch_body
      *
-     * @return Query
+     * @return $this
      */
-    public function fetchBody(bool $fetch_body): Query {
+    public function fetchBody(bool $fetch_body): static {
         return $this->setFetchBody($fetch_body);
     }
 
@@ -895,9 +895,9 @@ class Query {
      * Set the fetch flag
      * @param bool $fetch_flags
      *
-     * @return Query
+     * @return $this
      */
-    public function setFetchFlags(bool $fetch_flags): Query {
+    public function setFetchFlags(bool $fetch_flags): static {
         $this->fetch_flags = $fetch_flags;
         return $this;
     }
@@ -906,9 +906,9 @@ class Query {
      * Set the fetch order
      * @param string $fetch_order
      *
-     * @return Query
+     * @return $this
      */
-    public function setFetchOrder(string $fetch_order): Query {
+    public function setFetchOrder(string $fetch_order): static {
         $fetch_order = strtolower($fetch_order);
 
         if (in_array($fetch_order, ['asc', 'desc'])) {
@@ -922,9 +922,9 @@ class Query {
      * Set the fetch order
      * @param string $fetch_order
      *
-     * @return Query
+     * @return $this
      */
-    public function fetchOrder(string $fetch_order): Query {
+    public function fetchOrder(string $fetch_order): static {
         return $this->setFetchOrder($fetch_order);
     }
 
@@ -940,36 +940,36 @@ class Query {
     /**
      * Set the fetch order to ascending
      *
-     * @return Query
+     * @return $this
      */
-    public function setFetchOrderAsc(): Query {
+    public function setFetchOrderAsc(): static {
         return $this->setFetchOrder('asc');
     }
 
     /**
      * Set the fetch order to ascending
      *
-     * @return Query
+     * @return $this
      */
-    public function fetchOrderAsc(): Query {
+    public function fetchOrderAsc(): static {
         return $this->setFetchOrderAsc();
     }
 
     /**
      * Set the fetch order to descending
      *
-     * @return Query
+     * @return $this
      */
-    public function setFetchOrderDesc(): Query {
+    public function setFetchOrderDesc(): static {
         return $this->setFetchOrder('desc');
     }
 
     /**
      * Set the fetch order to descending
      *
-     * @return Query
+     * @return $this
      */
-    public function fetchOrderDesc(): Query {
+    public function fetchOrderDesc(): static {
         return $this->setFetchOrderDesc();
     }
 
@@ -977,9 +977,9 @@ class Query {
      * Set soft fail mode
      * @var boolean $state
      *
-     * @return Query
+     * @return $this
      */
-    public function softFail(bool $state = true): Query {
+    public function softFail(bool $state = true): static {
         return $this->setSoftFail($state);
     }
 
@@ -987,9 +987,9 @@ class Query {
      * Set soft fail mode
      *
      * @var boolean $state
-     * @return Query
+     * @return $this
      */
-    public function setSoftFail(bool $state = true): Query {
+    public function setSoftFail(bool $state = true): static {
         $this->soft_fail = $state;
 
         return $this;

--- a/src/Query/WhereQuery.php
+++ b/src/Query/WhereQuery.php
@@ -132,7 +132,7 @@ class WhereQuery extends Query {
      * $query->where(["FROM" => "someone@email.tld", "SEEN"]);
      * $query->where("FROM", "someone@email.tld")->where("SEEN");
      */
-    public function where(mixed $criteria, mixed $value = null): WhereQuery {
+    public function where(mixed $criteria, mixed $value = null): static {
         if (is_array($criteria)) {
             foreach ($criteria as $key => $value) {
                 if (is_numeric($key)) {
@@ -171,7 +171,7 @@ class WhereQuery extends Query {
      *
      * @return $this
      */
-    public function orWhere(Closure $closure = null): WhereQuery {
+    public function orWhere(Closure $closure = null): static {
         $this->query->push(['OR']);
         if ($closure !== null) $closure($this);
 
@@ -183,7 +183,7 @@ class WhereQuery extends Query {
      *
      * @return $this
      */
-    public function andWhere(Closure $closure = null): WhereQuery {
+    public function andWhere(Closure $closure = null): static {
         $this->query->push(['AND']);
         if ($closure !== null) $closure($this);
 
@@ -191,38 +191,38 @@ class WhereQuery extends Query {
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereAll(): WhereQuery {
+    public function whereAll(): static {
         return $this->where('ALL');
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereAnswered(): WhereQuery {
+    public function whereAnswered(): static {
         return $this->where('ANSWERED');
     }
 
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereBcc(string $value): WhereQuery {
+    public function whereBcc(string $value): static {
         return $this->where('BCC', $value);
     }
 
     /**
      * @param mixed $value
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      * @throws MessageSearchValidationException
      */
-    public function whereBefore(mixed $value): WhereQuery {
+    public function whereBefore(mixed $value): static {
         $date = $this->parse_date($value);
         return $this->where('BEFORE', $date);
     }
@@ -230,121 +230,121 @@ class WhereQuery extends Query {
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereBody(string $value): WhereQuery {
+    public function whereBody(string $value): static {
         return $this->where('BODY', $value);
     }
 
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereCc(string $value): WhereQuery {
+    public function whereCc(string $value): static {
         return $this->where('CC', $value);
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereDeleted(): WhereQuery {
+    public function whereDeleted(): static {
         return $this->where('DELETED');
     }
 
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereFlagged(string $value): WhereQuery {
+    public function whereFlagged(string $value): static {
         return $this->where('FLAGGED', $value);
     }
 
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereFrom(string $value): WhereQuery {
+    public function whereFrom(string $value): static {
         return $this->where('FROM', $value);
     }
 
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereKeyword(string $value): WhereQuery {
+    public function whereKeyword(string $value): static {
         return $this->where('KEYWORD', $value);
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereNew(): WhereQuery {
+    public function whereNew(): static {
         return $this->where('NEW');
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereNot(): WhereQuery {
+    public function whereNot(): static {
         return $this->where('NOT');
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereOld(): WhereQuery {
+    public function whereOld(): static {
         return $this->where('OLD');
     }
 
     /**
      * @param mixed $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws MessageSearchValidationException
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereOn(mixed $value): WhereQuery {
+    public function whereOn(mixed $value): static {
         $date = $this->parse_date($value);
         return $this->where('ON', $date);
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereRecent(): WhereQuery {
+    public function whereRecent(): static {
         return $this->where('RECENT');
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereSeen(): WhereQuery {
+    public function whereSeen(): static {
         return $this->where('SEEN');
     }
 
     /**
      * @param mixed $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws MessageSearchValidationException
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereSince(mixed $value): WhereQuery {
+    public function whereSince(mixed $value): static {
         $date = $this->parse_date($value);
         return $this->where('SINCE', $date);
     }
@@ -352,88 +352,88 @@ class WhereQuery extends Query {
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereSubject(string $value): WhereQuery {
+    public function whereSubject(string $value): static {
         return $this->where('SUBJECT', $value);
     }
 
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereText(string $value): WhereQuery {
+    public function whereText(string $value): static {
         return $this->where('TEXT', $value);
     }
 
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereTo(string $value): WhereQuery {
+    public function whereTo(string $value): static {
         return $this->where('TO', $value);
     }
 
     /**
      * @param string $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereUnkeyword(string $value): WhereQuery {
+    public function whereUnkeyword(string $value): static {
         return $this->where('UNKEYWORD', $value);
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereUnanswered(): WhereQuery {
+    public function whereUnanswered(): static {
         return $this->where('UNANSWERED');
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereUndeleted(): WhereQuery {
+    public function whereUndeleted(): static {
         return $this->where('UNDELETED');
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereUnflagged(): WhereQuery {
+    public function whereUnflagged(): static {
         return $this->where('UNFLAGGED');
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereUnseen(): WhereQuery {
+    public function whereUnseen(): static {
         return $this->where('UNSEEN');
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereNoXSpam(): WhereQuery {
+    public function whereNoXSpam(): static {
         return $this->where("CUSTOM X-Spam-Flag NO");
     }
 
     /**
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereIsXSpam(): WhereQuery {
+    public function whereIsXSpam(): static {
         return $this->where("CUSTOM X-Spam-Flag YES");
     }
 
@@ -442,10 +442,10 @@ class WhereQuery extends Query {
      * @param $header
      * @param $value
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereHeader($header, $value): WhereQuery {
+    public function whereHeader($header, $value): static {
         return $this->where("CUSTOM HEADER $header $value");
     }
 
@@ -453,10 +453,10 @@ class WhereQuery extends Query {
      * Search for a specific message id
      * @param $messageId
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereMessageId($messageId): WhereQuery {
+    public function whereMessageId($messageId): static {
         return $this->whereHeader("Message-ID", $messageId);
     }
 
@@ -464,20 +464,20 @@ class WhereQuery extends Query {
      * Search for a specific message id
      * @param $messageId
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereInReplyTo($messageId): WhereQuery {
+    public function whereInReplyTo($messageId): static {
         return $this->whereHeader("In-Reply-To", $messageId);
     }
 
     /**
      * @param $country_code
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereLanguage($country_code): WhereQuery {
+    public function whereLanguage($country_code): static {
         return $this->where("Content-Language $country_code");
     }
 
@@ -486,10 +486,10 @@ class WhereQuery extends Query {
      *
      * @param int|string $uid
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereUid(int|string $uid): WhereQuery {
+    public function whereUid(int|string $uid): static {
         return $this->where('UID', $uid);
     }
 
@@ -498,10 +498,10 @@ class WhereQuery extends Query {
      *
      * @param array<int, int> $uids
      *
-     * @return WhereQuery
+     * @return $this
      * @throws InvalidWhereQueryCriteriaException
      */
-    public function whereUidIn(array $uids): WhereQuery {
+    public function whereUidIn(array $uids): static {
         $uids = implode(',', $uids);
         return $this->where('UID', $uids);
     }


### PR DESCRIPTION
First of, thank you for this package! Its a great library that has had a great and positive impact on our work.

While using this package I found that the type-hinting for some of the methods wasn't optimal. This meant that using functions such as `fetchOrderDesc` meant you could no longer receive type hints for the `WhereQuery` methods.

I have implemented two changes in this PR:

Firstly, I have re-typed all function return type hints to `static`. This is more truthful than saying it returns itself -- if you were to extend these classes (such as the WhereQuery does the Query) then the reality is that it will return the subclass when these methods are called; hence `static` as its context aware.

Secondly, I have changed all the return docblocks to `@return $this` where they were previously set otherwise. Most of the functions followed this pattern anyway, but there were a couple that seemed to be forgotten about.

Functionally, nothing has changed - but it allows editors to decipher and understand what is happening more easily.

If you'd prefer to not change the return type hints and only do this through the docblocks, I am happy to revert the change to the return type hints.

Many thanks,
Ollie Scase
~ techlove