### PR TITLE
Fix Empty Child Folder Error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -585,7 +585,7 @@ class Client {
                 if ($hierarchical && $folder->hasChildren()) {
                     $pattern = $folder->full_name.$folder->delimiter.'%';
 
-                    $children = $this->getFolders(true, $pattern, $soft_fail);
+                    $children = $this->getFolders(true, $pattern, true);
                     $folder->setChildren($children);
                 }
 
@@ -631,7 +631,7 @@ class Client {
                 if ($hierarchical && $folder->hasChildren()) {
                     $pattern = $folder->full_name.$folder->delimiter.'%';
 
-                    $children = $this->getFoldersWithStatus(true, $pattern, $soft_fail);
+                    $children = $this->getFoldersWithStatus(true, $pattern, true);
                     $folder->setChildren($children);
                 }
 


### PR DESCRIPTION
I have multiple Outlook 365 accounts that are receiving the `failed to fetch any folders` exception. The problem is happening on the `Contacts` and `Conversation History` folders. These have the `HasChildren` flag set but there are no child folders. Contacts is not a message folder and I suspect is related to the contact address book. Conversation History can store messages and have subfolders, but there are none right now. It seems incorrect that `HasChildren` is set, but this ends up causing an exception to be thrown when looking for those subfolders even though many primary folders were successfully found. 

This can be fixed by setting `$soft_fail` to `true` only when checking the child folders. If no child folders are found it can continue on normally and return all of the folders that were found. This will still throw the normal exception if the primary folders were not found.

This resolves Issue #453 

![image](https://github.com/Webklex/php-imap/assets/5347727/31fc3208-022d-4133-b2c0-f567451936e4)
