### PR TITLE
Fix - Query - Chunked - Resolved infinite loop when start chunk > 1

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -395,8 +395,14 @@ class Query {
      * @throws ResponseException
      */
     public function chunked(callable $callback, int $chunk_size = 10, int $start_chunk = 1): void {
+        $start_chunk = max($start_chunk,1);
+        $chunk_size = max($chunk_size,1);
+        $skipped_messages_count = $chunk_size * ($start_chunk-1);
+
         $available_messages = $this->search();
-        if (($available_messages_count = $available_messages->count()) > 0) {
+        $available_messages_count = max($available_messages->count() - $skipped_messages_count,0);
+
+        if ($available_messages_count > 0) {
             $old_limit = $this->limit;
             $old_page = $this->page;
 


### PR DESCRIPTION
Resolved an issue when the start chunks value was > 1 an infinite loop would be created as handled messages would always be less than available messages.

Added more safety around input arguments, forcing minimums of 1 for both $chunk_size and $start_chunk.