### PR TITLE
Fix: Attachment::decodeName remove .. from file name

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -314,7 +314,12 @@ class Attachment {
 
             // sanitize $name
             // order of '..' is important
-            return str_replace(['\\', '/', chr(0), ':', '..'], '', $name);
+            $replaces = [
+                '/\\\\/' => '',
+                '/[\/\0:]+/' => '',
+                '/\.+/' => '.',
+            ];
+            return preg_replace(array_keys($replaces), array_values($replaces), $name);
         }
         return "";
     }

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Tests\fixtures\FixtureTestCase;
+use Webklex\PHPIMAP\Attachment;
+
+class AttachmentTest extends FixtureTestCase
+{
+    protected Attachment $attachment;
+
+    public function setUp(): void
+    {
+        $message = $this->getFixture("attachment_encoded_filename.eml");
+        $this->attachment = $message->getAttachments()->first();
+    }
+    /**
+     * @dataProvider decodeNameDataProvider
+     */
+    public function testDecodeName(string $input, string $output): void
+    {
+        $name = $this->attachment->decodeName($input);
+        $this->assertEquals($output, $name);
+    }
+
+    public function decodeNameDataProvider(): array
+    {
+        return [
+            ['../../../../../../../../../../../var/www/shell.php', '.varwwwshell.php'],
+            ['test..xml', 'test.xml'],
+            [chr(0), ''],
+            ['C:\\file.txt', 'Cfile.txt'],
+        ];
+    }
+}


### PR DESCRIPTION
If attached file has name like test..xml, then dots remove and broke file extension.