### PR TITLE
feat: client->getFolderPath return null if folder is not set.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -773,7 +773,7 @@ class Client {
     /**
      * Get the current active folder
      *
-     * @return string
+     * @return null|string
      */
     public function getFolderPath(): ?string {
         return $this->active_folder;

--- a/src/Client.php
+++ b/src/Client.php
@@ -775,7 +775,7 @@ class Client {
      *
      * @return string
      */
-    public function getFolderPath(): string {
+    public function getFolderPath(): ?string {
         return $this->active_folder;
     }
 


### PR DESCRIPTION
For fixing this issue 

> Webklex\PHPIMAP\Client::getFolderPath(): Return value must be of type string, null returned    