### PR TITLE
Added SSL stream context options

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -100,6 +100,16 @@ class Client {
         'password' => null,
     ];
 
+
+    /**
+     * SSL stream context options
+     *
+     * @see https://www.php.net/manual/en/context.ssl.php for possible options
+     *
+     * @var array
+     */
+    protected array $ssl_options = [];
+
     /**
      * Connection timeout
      * @var int $timeout
@@ -184,7 +194,8 @@ class Client {
             'username' => null,
             'password' => null,
         ],
-        "timeout" => 30
+        'ssl_options' => [],
+        "timeout" => 30,
     ];
 
     /**
@@ -436,6 +447,7 @@ class Client {
             $this->connection = new ImapProtocol($this->config, $this->validate_cert, $this->encryption);
             $this->connection->setConnectionTimeout($this->timeout);
             $this->connection->setProxy($this->proxy);
+            $this->connection->setSslOptions($this->ssl_options);
         }else{
             if (extension_loaded('imap') === false) {
                 throw new ConnectionFailedException("connection setup failed", 0, new ProtocolNotSupportedException($protocol." is an unsupported protocol"));

--- a/src/Connection/Protocols/Protocol.php
+++ b/src/Connection/Protocols/Protocol.php
@@ -72,6 +72,15 @@ abstract class Protocol implements ProtocolInterface {
     ];
 
     /**
+     * SSL stream context options
+     *
+     * @see https://www.php.net/manual/en/context.ssl.php for possible options
+     *
+     * @var array
+     */
+    protected array $ssl_options = [];
+
+    /**
      * Cache for uid of active folder.
      *
      * @var array
@@ -163,6 +172,28 @@ abstract class Protocol implements ProtocolInterface {
     }
 
     /**
+     * Set SSL context options settings
+     * @var array $options
+     *
+     * @return Protocol
+     */
+    public function setSslOptions(array $options): Protocol
+    {
+        $this->ssl_options = $options;
+
+        return $this;
+    }
+
+    /**
+     * Get the current SSL context options settings
+     *
+     * @return array
+     */
+    public function getSslOptions(): array {
+        return $this->ssl_options;
+    }
+
+    /**
      * Prepare socket options
      * @return array
      *@var string $transport
@@ -175,6 +206,11 @@ abstract class Protocol implements ProtocolInterface {
                 'verify_peer_name' => $this->getCertValidation(),
                 'verify_peer'      => $this->getCertValidation(),
             ];
+
+            if (count($this->ssl_options)) {
+                /* Get the ssl context options from the config, but prioritize the 'validate_cert' config over the ssl context options */
+                $options["ssl"] = array_replace($this->ssl_options, $options["ssl"]);
+            }
         }
 
         if ($this->proxy["socket"] != null) {

--- a/tests/ImapProtocolTest.php
+++ b/tests/ImapProtocolTest.php
@@ -48,5 +48,17 @@ class ImapProtocolTest extends TestCase {
 
         self::assertSame(true, $protocol->getCertValidation());
         self::assertSame("ssl", $protocol->getEncryption());
+
+        $protocol->setSslOptions([
+            'verify_peer' => true,
+            'cafile' => '/dummy/path/for/testing',
+            'peer_fingerprint' => ['md5' => 40],
+        ]);
+
+        self::assertSame([
+            'verify_peer' => true,
+            'cafile' => '/dummy/path/for/testing',
+            'peer_fingerprint' => ['md5' => 40],
+        ], $protocol->getSslOptions());
     }
 }


### PR DESCRIPTION
Hi,

As mentioned in this issue #238 , I added a way to set SSL related stream context options.

I only added the SSL stream context options, as the only other available stream context options for the imap protocol are the [socket options](https://www.php.net/manual/en/context.socket.php), which I found very specifics (way more than the SSL ones).

I tested the feature with a few Dovecot Docker containers with custom CA or unsecure TLS version.
It works as intended to specify a CA file or a list of ciphers.

I did not set a closed list of SSL options, as from my tests, if an unknown SSL options, or if a wrong value is passed to `stream_context_create()`, it will be ignored.
However, if needed, it is possible to restrict the options names and check the value types. 

Kind regards,