### PR TITLE
Public search() method for Query

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -193,7 +193,7 @@ class Query {
      * @throws ImapServerErrorException
      * @throws ResponseException
      */
-    protected function search(): Collection {
+    public function search(): Collection {
         $this->generate_query();
 
         try {


### PR DESCRIPTION
Just set the `search()` method of `Query` as public.

This would be incredibly useful to obtain just UIDs of messages, and - for example - to keep a local index of UID and sequence numbers to map EXPUNGEd messages.