### PR TITLE
Fix remaining implicit marking of parameters as nullable (PHP 8.4)

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -462,7 +462,7 @@ class Attachment {
      * @return mixed
      * @throws MaskNotFoundException
      */
-    public function mask(string $mask = null): mixed {
+    public function mask(?string $mask = null): mixed {
         $mask = $mask !== null ? $mask : $this->mask;
         if (class_exists($mask)) {
             return new $mask($this);

--- a/src/Decoder/Decoder.php
+++ b/src/Decoder/Decoder.php
@@ -54,7 +54,7 @@ abstract class Decoder implements DecoderInterface {
      * @param string|null $encoding
      * @return mixed
      */
-    public function decode(array|string|null $value, string $encoding = null): mixed {
+    public function decode(array|string|null $value, ?string $encoding = null): mixed {
         return $value;
     }
 

--- a/src/Decoder/DecoderInterface.php
+++ b/src/Decoder/DecoderInterface.php
@@ -33,7 +33,7 @@ interface DecoderInterface {
      * @param string|null $encoding
      * @return string|array|null
      */
-    public function decode(array|string|null $value, string $encoding = null): mixed;
+    public function decode(array|string|null $value, ?string $encoding = null): mixed;
 
     public function mimeHeaderDecode(string $text): array;
 

--- a/src/Decoder/HeaderDecoder.php
+++ b/src/Decoder/HeaderDecoder.php
@@ -21,7 +21,7 @@ use Webklex\PHPIMAP\EncodingAliases;
  */
 class HeaderDecoder extends Decoder {
 
-    public function decode(array|string|null $value, string $encoding = null): mixed {
+    public function decode(array|string|null $value, ?string $encoding = null): mixed {
         if (is_array($value)) {
             return $this->decodeHeaderArray($value);
         }

--- a/src/Decoder/MessageDecoder.php
+++ b/src/Decoder/MessageDecoder.php
@@ -23,7 +23,7 @@ use Webklex\PHPIMAP\IMAP;
  */
 class MessageDecoder extends Decoder {
 
-    public function decode(array|string|null $value, string $encoding = null): mixed {
+    public function decode(array|string|null $value, ?string $encoding = null): mixed {
         if(is_array($value)) {
             return array_map(function($item){
                 return $this->decode($item);

--- a/tests/fixtures/FixtureTestCase.php
+++ b/tests/fixtures/FixtureTestCase.php
@@ -84,7 +84,7 @@ abstract class FixtureTestCase extends TestCase {
      * @throws ResponseException
      * @throws RuntimeException
      */
-    final public function getFixture(string $template, Config $config = null) : Message {
+    final public function getFixture(string $template, ?Config $config = null) : Message {
         $filename = implode(DIRECTORY_SEPARATOR, [__DIR__, "..",  "messages", $template]);
         $message = Message::fromFile($filename, $config);
         self::assertInstanceOf(Message::class, $message);

--- a/tests/live/LegacyTest.php
+++ b/tests/live/LegacyTest.php
@@ -236,7 +236,7 @@ class LegacyTest extends TestCase {
      * @throws ResponseException
      * @throws RuntimeException
      */
-    final protected function deleteFolder(Folder $folder = null): bool {
+    final protected function deleteFolder(?Folder $folder = null): bool {
         $response = $folder?->delete(false);
         if (is_array($response)) {
             $valid_response = false;
@@ -423,7 +423,7 @@ class LegacyTest extends TestCase {
      * @throws ResponseException
      * @throws RuntimeException
      */
-    protected function assertWhereSearchCriteria(Folder $folder, string $criteria, Carbon|string $value = null, bool $date = false): void {
+    protected function assertWhereSearchCriteria(Folder $folder, string $criteria, Carbon|string|null $value = null, bool $date = false): void {
         $query = $folder->query()->where($criteria, $value);
         self::assertInstanceOf(WhereQuery::class, $query);
 

--- a/tests/live/LiveMailboxTestCase.php
+++ b/tests/live/LiveMailboxTestCase.php
@@ -200,7 +200,7 @@ abstract class LiveMailboxTestCase extends TestCase {
      * @throws ResponseException
      * @throws RuntimeException
      */
-    final protected function deleteFolder(Folder $folder = null): bool {
+    final protected function deleteFolder(?Folder $folder = null): bool {
         $response = $folder?->delete(false);
         if (is_array($response)) {
             $valid_response = false;

--- a/tests/live/QueryTest.php
+++ b/tests/live/QueryTest.php
@@ -231,7 +231,7 @@ class QueryTest extends LiveMailboxTestCase {
      * @throws ResponseException
      * @throws RuntimeException
      */
-    protected function assertWhereSearchCriteria(Folder $folder, string $criteria, Carbon|string $value = null, bool $date = false): void {
+    protected function assertWhereSearchCriteria(Folder $folder, string $criteria, Carbon|string|null $value = null, bool $date = false): void {
         $query = $folder->query()->where($criteria, $value);
         self::assertInstanceOf(WhereQuery::class, $query);
 


### PR DESCRIPTION
> Webklex\PHPIMAP\Decoder\MessageDecoder::decode(): Implicitly marking parameter $encoding as nullable is deprecated, the explicit nullable type must be used instead in vendor/webklex/php-imap/src/Decoder/MessageDecoder.php:26

Found more occurences using `find . -name *.php -exec php -l {} \;` and fixed them all.