### PR TITLE
Fix case sensitivity of folder attribute parsing (\NoSelect, \NoInferiors) #469

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [UNRELEASED]
 ### Fixed
-- NaN
+- Fix case sensitivity of Folder attribute parsing (\NoSelect, \NoInferiors) #469 (thanks @smajti1)
 
 ### Added
 - SSL stream context options added #238 #546 (thanks @llemoine)

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -259,8 +259,8 @@ class Folder {
      * @param $attributes
      */
     protected function parseAttributes($attributes): void {
-        $this->no_inferiors = in_array('\NoInferiors', $attributes);
-        $this->no_select = in_array('\NoSelect', $attributes);
+        $this->no_inferiors = in_array('\NoInferiors', $attributes, true) || \in_array('\Noinferiors', $attributes, true);
+        $this->no_select = in_array('\NoSelect', $attributes, true) || \in_array('\Noselect', $attributes, true);
         $this->marked = in_array('\Marked', $attributes);
         $this->referral = in_array('\Referral', $attributes);
         $this->has_children = in_array('\HasChildren', $attributes);

--- a/tests/issues/Issue469Test.php
+++ b/tests/issues/Issue469Test.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\issues;
+
+use PHPUnit\Framework\TestCase;
+use Webklex\PHPIMAP\Client;
+use Webklex\PHPIMAP\Folder;
+
+class Issue469Test extends TestCase {
+
+    /**
+     * Test issue #469 - Case sensitive \NoSelect flag check doesn't work for Gmail
+     */
+    public function testIssue(): void {
+		$client = $this->createStub(Client::class);
+		$folder_name = '[Gmail]';
+		$delimiter = '/';
+
+		$attributes = [
+			'\NoInferiors',
+			'\NoSelect',
+		];
+		$folder = new Folder($client, $folder_name, $delimiter, $attributes);
+
+		$attributes_lowercase = [
+			'\Noinferiors',
+			'\Noselect',
+		];
+		$folder_lowercase = new Folder($client, $folder_name, $delimiter, $attributes_lowercase);
+
+		self::assertSame(
+			$folder->no_inferiors,
+			$folder_lowercase->no_inferiors,
+			'The parsed "\NoInferiors" attribute does not match the parsed "\Noinferiors" attribute'
+		);
+		self::assertSame(
+			$folder->no_select,
+			$folder_lowercase->no_select,
+			'The parsed "\NoSelect" attribute does not match the parsed "\Noselect" attribute'
+		);
+	}
+}


### PR DESCRIPTION
It should fix https://github.com/Webklex/php-imap/issues/469
Base on https://datatracker.ietf.org/doc/html/rfc3501#section-7.2.2 i also add check for `\Noinferiors` attribute

I have yet considered changing this function, to some thing like this:
```
protected function parseAttributes($attributes): void
{
	$normalized_attributes = array_map('strtolower', $attributes);

	$this->no_inferiors = in_array('\noinferiors', $normalized_attributes, true);
	$this->no_select = in_array('\noselect', $normalized_attributes, true);
	$this->marked = in_array('\marked', $normalized_attributes, true);
	$this->referral = in_array('\referral', $normalized_attributes, true);
	$this->has_children = in_array('\haschildren', $normalized_attributes, true);
}
```