### PR TITLE
Fix error on getUid(null) with 0 results (#499)

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -939,7 +939,7 @@ class ImapProtocol extends Protocol {
         $uids = $this->uid_cache;
 
         if ($id == null) {
-            return Response::empty($this->debug)->setResult($uids);
+            return Response::empty($this->debug)->setResult($uids)->setCanBeEmpty(true);
         }
 
         foreach ($uids as $k => $v) {


### PR DESCRIPTION
The `Response` objects returned by `ImapProtocol::getUid()` have their "can_be_empty" flag set to the default of false. That is not correct when `$id` is set to null, since if we don't have a specific id to fetch, it's also possible there are no messages in the folder.
