### PR TITLE
Reading whole lines from stream

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -135,14 +135,10 @@ class ImapProtocol extends Protocol {
      * @throws RuntimeException
      */
     public function nextLine(Response $response): string {
-        $line = "";
-        while (($next_char = fread($this->stream, 1)) !== false && !in_array($next_char, ["", "\n"])) {
-            $line .= $next_char;
-        }
-        if ($line === "" && ($next_char === false || $next_char === "")) {
+        $line = fgets($this->stream);
+        if ($line === false || $line === '') {
             throw new RuntimeException('empty response');
         }
-        $line .= "\n";
         $response->addResponse($line);
         if ($this->debug) echo "<< " . $line;
         return $line;


### PR DESCRIPTION
Replaced char-by-char retrieval from stream via `fread()` with `fgets()` to get full line from stream until EOF or newline. This speeds up data transfer by factor 10.

The original code reads single characters from stream until `fread()` fails, returns empty char or newline. That causes a really huge loop for retrieving emails having bigger attachments. This is not different from using `fgets()` which might fail or return empty string. But if there is any data, it should be trailed by a newline character. My change behaves in the same way the original code does.

Querying a simple IMAP mailbox that contains 3 emails with attachments (1x 10MB, 2x 5MB attachments), the original code runs for more than 30 seconds to retrieve the emails. Applying the change, the script finishes after 3 seconds.