### PR TITLE
Recursive handling of stdClass in response

### DIFF
--- a/src/Connection/Protocols/ImapProtocol.php
+++ b/src/Connection/Protocols/ImapProtocol.php
@@ -135,14 +135,10 @@ class ImapProtocol extends Protocol {
      * @throws RuntimeException
      */
     public function nextLine(Response $response): string {
-        $line = "";
-        while (($next_char = fread($this->stream, 1)) !== false && !in_array($next_char, ["", "\n"])) {
-            $line .= $next_char;
-        }
-        if ($line === "" && ($next_char === false || $next_char === "")) {
+        $line = fgets($this->stream);
+        if ($line === false || $line === '') {
             throw new RuntimeException('empty response');
         }
-        $line .= "\n";
         $response->addResponse($line);
         if ($this->debug) echo "<< " . $line;
         return $line;

--- a/src/Connection/Protocols/Response.php
+++ b/src/Connection/Protocols/Response.php
@@ -13,6 +13,7 @@
 
 namespace Webklex\PHPIMAP\Connection\Protocols;
 
+use stdClass;
 use Webklex\PHPIMAP\Exceptions\ResponseException;
 
 /**
@@ -347,7 +348,7 @@ class Response {
      * @return bool
      */
     public function verify_data(mixed $data): bool {
-        if (is_array($data)) {
+        if (is_array($data) || $data instanceof stdClass) {
             foreach ($data as $line) {
                 if (is_array($line)) {
                     if(!$this->verify_data($line)){

--- a/src/Decoder/HeaderDecoder.php
+++ b/src/Decoder/HeaderDecoder.php
@@ -29,7 +29,9 @@ class HeaderDecoder extends Decoder {
         $decoder = $this->options['header'];
 
         if ($value !== null) {
-            if ($decoder === 'utf-8') {
+            if (self::isUTF8($value)) {
+                $value = mb_decode_mimeheader($value);
+            } else if ($decoder === 'utf-8') {
                 $decoded_values = $this->mimeHeaderDecode($value);
                 $tempValue = "";
                 foreach ($decoded_values as $decoded_value) {
@@ -46,8 +48,6 @@ class HeaderDecoder extends Decoder {
                 }
             } elseif ($decoder === 'iconv') {
                 $value = iconv_mime_decode($value, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, "UTF-8");
-            } else if (self::isUTF8($value)) {
-                $value = mb_decode_mimeheader($value);
             }
 
             if (self::notDecoded($original_value, $value)) {

--- a/src/Decoder/HeaderDecoder.php
+++ b/src/Decoder/HeaderDecoder.php
@@ -29,9 +29,7 @@ class HeaderDecoder extends Decoder {
         $decoder = $this->options['header'];
 
         if ($value !== null) {
-            if (self::isUTF8($value)) {
-                $value = mb_decode_mimeheader($value);
-            } else if ($decoder === 'utf-8') {
+            if ($decoder === 'utf-8') {
                 $decoded_values = $this->mimeHeaderDecode($value);
                 $tempValue = "";
                 foreach ($decoded_values as $decoded_value) {
@@ -48,6 +46,8 @@ class HeaderDecoder extends Decoder {
                 }
             } elseif ($decoder === 'iconv') {
                 $value = iconv_mime_decode($value, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, "UTF-8");
+            } else if (self::isUTF8($value)) {
+                $value = mb_decode_mimeheader($value);
             }
 
             if (self::notDecoded($original_value, $value)) {


### PR DESCRIPTION
For example, calling `overview()` on a folder using `LegacyProcotol` (i.e. POP3) can result in error `Error: Object of class stdClass could not be converted to string in /path/to/code/webklex/php-imap/src/Connection/Protocols/Response.php:365`, because response might contain `stdClass` object which is not yet handled recursively by `verify_data()`.

Because `stdClass` is handled in a similar way like arrays in PHP, we can simply add check for `$data instanceof stdClass` to IF-clause in `verify_data()` and recursive processing is done by existing code then.