### PR TITLE
fix for multipart messages with just 1 part (Fixes #580)

### DIFF
--- a/src/Structure.php
+++ b/src/Structure.php
@@ -115,7 +115,7 @@ class Structure {
         if (($boundary = $headers->getBoundary()) !== null) {
             $parts = $this->detectParts($boundary, $body, $part_number);
 
-            if(count($parts) > 1) {
+            if(count($parts) > 0) {
                 return $parts;
             }
         }

--- a/tests/issues/Issue580Test.php
+++ b/tests/issues/Issue580Test.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\issues;
+
+use PHPUnit\Framework\TestCase;
+use Tests\fixtures\FixtureTestCase;
+use Webklex\PHPIMAP\Attachment;
+use Webklex\PHPIMAP\ClientManager;
+use Webklex\PHPIMAP\Exceptions\AuthFailedException;
+use Webklex\PHPIMAP\Exceptions\ConnectionFailedException;
+use Webklex\PHPIMAP\Exceptions\ImapBadRequestException;
+use Webklex\PHPIMAP\Exceptions\ImapServerErrorException;
+use Webklex\PHPIMAP\Exceptions\InvalidMessageDateException;
+use Webklex\PHPIMAP\Exceptions\MaskNotFoundException;
+use Webklex\PHPIMAP\Exceptions\MessageContentFetchingException;
+use Webklex\PHPIMAP\Exceptions\ResponseException;
+use Webklex\PHPIMAP\Exceptions\RuntimeException;
+
+class Issue580Test extends FixtureTestCase {
+
+    /**
+     * @throws RuntimeException
+     * @throws MessageContentFetchingException
+     * @throws ResponseException
+     * @throws ImapBadRequestException
+     * @throws InvalidMessageDateException
+     * @throws ConnectionFailedException
+     * @throws \ReflectionException
+     * @throws ImapServerErrorException
+     * @throws AuthFailedException
+     * @throws MaskNotFoundException
+     */
+    public function testIssueEmail() {
+        $message = $this->getFixture("issue-580.eml");
+
+        self::assertSame("html body in multipart related container is parsed as attachment", (string)$message->subject);
+
+        self::assertStringContainsString('This is a message in a multipart related container', $message->getHTMLBody());
+
+        $attachments = $message->getAttachments();
+        self::assertSame(0, $attachments->count());
+    }
+}

--- a/tests/messages/issue-580.eml
+++ b/tests/messages/issue-580.eml
@@ -1,0 +1,37 @@
+Return-Path: <ggg@example.de>
+Date: Thu, 20 Feb 2025 03:44:22 +0100 (CET)
+From: ggg@example.de
+To: contact@your-company.de, ggg@example.de
+Message-ID: <23975424.234.982154931647567.JavaMail.ggg@example.de>
+Subject: html body in multipart related container is parsed as attachment
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_Part_255_1307735605.1740019462622"
+
+------=_Part_255_1307735605.1740019462622
+Content-Type: multipart/related;
+	boundary="----=_Part_256_1484807935.1740019462623"
+
+------=_Part_256_1484807935.1740019462623
+Content-Type: text/html;charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    p {
+      font-family: "Helvetica Neue", "Segoe UI", Roboto, Arial, sans-serif;
+      font-size: 13px;
+    }
+  </style>
+</head>
+<body>
+<p>
+  This is a message in a multipart related container
+</p>
+</body>
+</html>
+------=_Part_256_1484807935.1740019462623--
+
+------=_Part_255_1307735605.1740019462622--


### PR DESCRIPTION
In the last change here it was incorrectly assumed that multipart always needs to contain multiple parts. There could also be just one.