### PR TITLE
Add support for IMAP keywords #607

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -1176,7 +1176,7 @@ class Message {
      */
     public function setFlag(array|string $flag): bool {
         $this->client->openFolder($this->folder_path);
-        $flag = "\\" . trim(is_array($flag) ? implode(" \\", $flag) : $flag);
+        $flag = self::sanitizeFlags($flag);
         $sequence_id = $this->getSequenceId();
         try {
             $status = $this->client->getConnection()->store([$flag], $sequence_id, $sequence_id, "+", true, $this->sequence)->validatedData();
@@ -1207,7 +1207,7 @@ class Message {
     public function unsetFlag(array|string $flag): bool {
         $this->client->openFolder($this->folder_path);
 
-        $flag = "\\" . trim(is_array($flag) ? implode(" \\", $flag) : $flag);
+        $flag = self::sanitizeFlags($flag);
         $sequence_id = $this->getSequenceId();
         try {
             $status = $this->client->getConnection()->store([$flag], $sequence_id, $sequence_id, "-", true, $this->sequence)->validatedData();
@@ -1255,6 +1255,19 @@ class Message {
      */
     public function removeFlag(array|string $flag): bool {
         return $this->unsetFlag($flag);
+    }
+
+    /**
+     * Format the flag string.
+     * Allows keywords like $MDNSent or $Forwarded
+     * @param array|string $flag
+     *
+     * @return string
+     */
+    public static function sanitizeFlags(array|string $flag): string {
+        return trim(is_array($flag)
+            ? (implode(" ", array_map(fn ($flag) => str_starts_with($flag, '$') ? $flag : "\\$flag", $flag)))
+            : (str_starts_with($flag, '$') ? $flag : "\\$flag"));
     }
 
     /**

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -263,6 +263,12 @@ class MessageTest extends TestCase {
         self::assertSame("application/pdf", $attachment->getMimeType());
     }
 
+    public function testSanitizeFlag(): void {
+        self::assertEquals('\\Seen', Message::sanitizeFlags('Seen'));
+        self::assertEquals('$Forwarded', Message::sanitizeFlags('$Forwarded'));
+        self::assertEquals('\\Seen $MDNSent $Junk \\Flagged', Message::sanitizeFlags(['Seen', '$MDNSent', '$Junk', 'Flagged']));
+    }
+
     /**
      * Create a new protocol mockup
      *


### PR DESCRIPTION
Hi,

As mentioned in #607, this is a proposed solution for allowing the usage of system defined keywords as flags.

This PR does not allow the use of custom keywords.